### PR TITLE
CE 1.5: environment dependency inventory + correlation hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - unreleased
+
+### Added — Environment Dependency Inventory & Correlation (CE 1.5)
+
+- **Environment and credential dependency inventory**
+  (`safeai/analyzers/env_dependency/`): a new analyzer records *references* to
+  external configuration and credentials — `os.getenv`/`os.environ`,
+  `process.env`, dotenv keys, shell/template interpolation, AWS Secrets
+  Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault, and Kubernetes
+  `secretKeyRef`. **Names and source locations only; values are never read,
+  masked, or stored**, preserving the source-private guarantee. Entries are
+  flagged `secret: true` when backed by a secret manager or a secret-ish name.
+- **Dependency-to-capability correlation**
+  (`safeai/analysis/dependency_correlation.py`): the inventory is matched
+  against the per-tool capability surface via a reviewable name-family keyword
+  model, producing two new findings:
+  - `DEP_UNDECLARED_CAPABILITY` (medium) — a referenced credential/config
+    family has no declared capability to consume it: a candidate undeclared
+    capability.
+  - `DEP_ORPHANED_TOOL` (low) — a credential-demanding capability is declared
+    with no matching credential/config reference anywhere: a probable dead or
+    misconfigured tool.
+- Correlation findings feed the severity counts, trust score, SARIF, terminal
+  and HTML outputs, and are written to the KYA manifest (`dependency_inventory`
+  and `dependency_correlation`, plus a `summary.dependency_count`).
+- New rules in `safeai/rules/base_rules.yaml`: `ENV_DEP_INVENTORY`,
+  `DEP_UNDECLARED_CAPABILITY`, `DEP_ORPHANED_TOOL`.
+
+### Fixed — CE 1.5 architecture review hardening
+
+- **Family matching is now word-segment based**
+  (`safeai/analysis/dependency_correlation.py`): names are split on
+  non-alphanumeric boundaries instead of raw substring matching, so short
+  tokens no longer false-positive inside unrelated words (e.g. `jdbc` no longer
+  maps to the database family via `db`). Provider-specific families
+  (`cloud`/`database`/`messaging`) take precedence over the generic `api`
+  fallback, keeping `SLACK_TOKEN` aligned with a declared `slack` capability and
+  eliminating simultaneous false `DEP_UNDECLARED_CAPABILITY` +
+  `DEP_ORPHANED_TOOL` pairs.
+- **Single scoring pass** (`safeai/engine/orchestrator.py`): correlation now
+  runs before the single count/score/relativize pass so its findings are
+  included exactly once; the second `_relativize_report()` call was removed.
+- **Payload-carrying findings are never suppressed**
+  (`safeai/kya/suppressions.py`): `ENV_DEP_INVENTORY` (and
+  `MCP_ASSETS_DISCOVERED`) are exempt from `apply_suppressions`, so a broad
+  `rule_id`/`path` suppression cannot blank the dependency-inventory section.
+
+### Notes
+
+- The informational `ENV_DEP_INVENTORY` finding is counted in the severity
+  breakdown and baseline; scans of repositories with a declared dependency
+  inventory will report one more finding than v1.4 for the same input.
+
 ## [1.4.0-beta] - 2026-08-02
 
 ### Added — Tool-Centric Capability Model & Escalation Detection

--- a/GOOD_FIRST_ISSUES.md
+++ b/GOOD_FIRST_ISSUES.md
@@ -2,11 +2,11 @@
 
 Welcome, and thank you for considering contributing to SafeAI!
 
-This document lists **29 beginner-friendly issues** designed for first-time contributors. Each issue includes the files you'll need to modify, the tests you should write, and the acceptance criteria.
+This document indexes **29 beginner-friendly issues** designed for first-time contributors (12 currently open). Each issue includes the files you'll need to modify, the tests you should write, and the acceptance criteria.
 
 > **For maintainers:** These issues are defined in `.github/good-first-issues/` as YAML templates. Run the [create-good-first-issues workflow](../../actions/workflows/create-good-first-issues.yml) to create them in the GitHub issue tracker with the `good first issue` label. Once created, this file serves as a curated index.
 
-> **14 issues have already been completed** by community contributors. See the [Completed Issues](#-completed-issues) section at the bottom.
+> **17 issues have already been completed** by community and internal contributors. See the [Completed Issues](#-completed-issues) section at the bottom.
 
 ---
 
@@ -88,19 +88,22 @@ This document lists **29 beginner-friendly issues** designed for first-time cont
 ## Reports & Output
 
 ### 16. Improve terminal output readability
+- **Status:** ✅ Complete (v1.4) — severity-grouped summary, explicit counts, `Highest escalation` line, coverage/assurance notes
 - **Difficulty:** Easy | **Effort:** 3–4 hours
 - **Suggested files:** `safeai/report/terminal.py`
-- **Description:** Restructure the terminal scan summary to be more readable. Community feedback highlights that the current output is functional but hard to scan quickly. Improvements could include severity-grouped findings, better section headers, color coding, and clearer signal-to-noise ratio. See the existing HTML report for design inspiration.
+- **Description:** Original task restructured the terminal scan summary for readability. Now delivered: grouping by severity, clearer section headers, and a better signal-to-noise ratio (informed by the HTML report design).
 
 ### 17. Improve HTML report — add filtering and search
+- **Status:** ✅ Complete (v1.4-b) — client-side filter + searchable tables via `safeai/report/html_kit.py` (`data_table`, `data-filter`)
 - **Difficulty:** Medium | **Effort:** 4–6 hours
-- **Suggested files:** `safeai/report/html.py`
+- **Suggested files:** `safeai/report/html.py`, `safeai/report/html_kit.py`
 
 ### 18. Improve SARIF output — add code flow
 - **Difficulty:** Medium | **Effort:** 3–4 hours
 - **Suggested files:** `safeai/report/sarif.py`
 
 ### 19. Add Markdown report generator
+- **Status:** 🔄 Partial — a Markdown reviewer summary ships via `--pr-comment` (`safeai/report/pr_comment.py`); a standalone `--format markdown` report generator is still open
 - **Difficulty:** Easy | **Effort:** 3–4 hours
 - **Suggested files:** `safeai/report/markdown.py`
 
@@ -121,9 +124,10 @@ This document lists **29 beginner-friendly issues** designed for first-time cont
 ## Scoring & Trust Score
 
 ### 23. Tune trust score weighting for critical and high findings
+- **Status:** ✅ Complete (v1.4) — severity weighting shipped via `SEVERITY_POINTS` in `safeai/severity.py` (critical 25 / high 15 / medium 8 / low 4 / info 1), consumed by `safeai/scoring/engine.py`; category weights remain configurable (`config_weights`)
 - **Difficulty:** Easy | **Effort:** 2–3 hours
-- **Suggested files:** `safeai/scoring/engine.py`
-- **Description:** Community feedback suggests giving more weight to critical and high-severity findings in the trust score calculation. Currently all categories have equal weight (1.0). Evaluate and adjust `CATEGORY_WEIGHTS` and `SEVERITY_POINTS` in `safeai/scoring/engine.py` to reflect higher impact of critical/high findings, then validate with existing test fixtures.
+- **Suggested files:** `safeai/scoring/engine.py`, `safeai/severity.py`
+- **Description:** Weighted severity now drives the trust score; the original equal-weight-per-category note is superseded.
 
 ---
 
@@ -180,6 +184,14 @@ These issues have been implemented by community contributors and are now part of
 | 17 | Detect Slack integration | @yugaaank (PR #2) |
 | 18 | Detect Jira integration | @yugaaank (PR #2) |
 | 19 | Detect browser automation capability | @yugaaank (PR #2) |
+
+### Reports, Output & Scoring
+
+| # | Issue | Contributor |
+|---|-------|-------------|
+| 16 | Improve terminal output readability | SafeAI (v1.4) |
+| 17 | Improve HTML report — add filtering and search | SafeAI (v1.4-b) |
+| 23 | Tune trust score weighting for critical/high findings | SafeAI (v1.4) |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,138 +2,198 @@
 
 SafeAI is a **Static AI Capability & Risk Analyzer** — think SonarQube for AI agents and workflows.
 
-This document describes the planned roadmap across five phases. Phases are not strictly sequential; work may proceed in parallel where dependencies allow.
+This document describes the roadmap across **two editions**: the open-source **Community Edition (Apache 2.0, offline, local-first)** and the commercial **Corporate Edition (evidence and governance plane)**. Milestones are not strictly sequential; work may proceed in parallel where dependencies allow.
+
+> **Current state:** v1.4-b shipped. Community Edition **CE 1.4 (Reviewable Change)** is substantially complete; planned work there is limited to a handful of governance and surface items. CE 1.5/1.6/2.0 and the entire Corporate Edition are planned.
 
 ---
 
-## Phase 1 — Static AI Risk Scanner (OSS)
+# Roadmap 1 — Community Edition (Apache 2.0, offline, local-first)
 
-*Current state — Phase 1 scope substantially complete; Phase 1.5 stabilization and community-driven depth improvements ongoing.*
+**Mission:** know your agent before you deploy it, with zero setup, no account, and no network.
 
-**Static analyzers implemented:**
+**Constraint:** if a feature does not improve a developer's ability to understand, remediate or prevent a risky agent change *before deployment*, it is not in the Community core.
 
-| Analyzer | Coverage | Status |
-|----------|----------|--------|
-| **Capabilities** | Shell, filesystem, HTTP, database, code execution, Docker, K8s, Redis, S3, Slack, Jira, browser automation, GCP | ✅ |
-| **Prompts** | Injection patterns, delimiter issues, system leaks, role overrides, untrusted placeholders | ✅ |
-| **Tools** | Agent-bound tool definitions, missing validation, dangerous params, shell access, excessive permissions | ✅ |
-| **Memory** | Checkpointer and memory object usage (framework parsers) | ✅ |
-| **Workflows** | Composition, approval gaps, insecure defaults, capability sprawl | ✅ |
-| **Identities** | Credential and secret exposure (hardcoded secrets, env references) | ✅ |
-| **Models** | LLM provider references, unsafe temperature, missing content filters, disabled safety | ✅ |
-| **Autonomy** | Loop detection, unbounded execution | ✅ |
-| **MCP** | Schema validation (v1.0/v1.1), auth gaps, exposed endpoints, tool misuse, sensitive resources, insecure transports | ✅ |
-
-**Outputs implemented:** JSON, HTML, SARIF 2.1.0, capability graph (project_graph), trust score, capability diff (`--baseline`), canonical manifest (`safeai-manifest.json`)
-
-**Release 1.3 delivered (KYA baseline + local registry):**
-
-- Canonical KYA manifest (`schema_version: 1.0`)
-- Stable finding IDs/fingerprints and status lifecycle (`new`, `existing`, `regressed`, `resolved`, `suppressed`)
-- Baseline-driven PR gating (`--fail-on-new`)
-- Local suppression workflow (`.safeai/suppressions.yml`)
-- Minimal policy-as-code (`.safeai/policy.yml`)
-- Local SQLite KYA registry and CLI (`registry list/show/history/diff/export`)
-
-**Still planned in Phase 1:**
-
-- **Governance signals** — timeout, retry policy, approval workflow, audit logging, rate limiting detection
-- **Heuristic data flows** — deeper untrusted input propagation into prompts
-- **PR capability escalation diff refinement** — improve branch/base automation and deeper authority/context deltas on top of existing baseline support.
-- **Governed finding suppressions** — every suppression carries rule_id, file, location, reason, owner, and expiry. CI fails when code moves or waiver expires. Stale-detection for forgotten suppressions.
-- **Better terminal output** — structured, readable scan summary with severity grouping, improved layout, and clearer signal-to-noise ratio
-- **Trust score improvements** — weighted scoring giving higher impact to critical and high-severity findings
+Status legend: ✅ **Shipped** · 🔄 **In progress / partial** · ⏳ **Planned**
 
 ---
 
-## Phase 1.5 — AI Component Security (Stabilization)
+## CE 1.4 — Reviewable Change (the PR release)
 
-*Partially complete — deep component analysis shipped in v1.1.0-beta; continued refinements.*
+*Goal: make SafeAI the thing a reviewer reads first on any PR that touches an agent.*
 
-**Artifact analysis implemented:**
+**Status: ✅ shipped (v1.3 → v1.4 → v1.4-b); a few items remain.**
 
-| Artifact | Analysis Focus | Status |
-|----------|---------------|--------|
-| **Skills** | Embedded prompts, excessive permissions, risky capabilities, insecure defaults, hardcoded secrets | ✅ |
-| **Prompts** | Injection resistance, system prompt exposure, role isolation, untrusted input | ✅ |
-| **MCP servers** | Auth gaps, endpoint exposure, tool misuse, sensitive resources, insecure transports | ✅ |
-| **Workflow templates** | Insecure defaults, capability sprawl, approval gaps, missing validation | ✅ |
-| **Tool definitions** | Overly broad permissions, missing validation, shell access, dangerous params | ✅ |
-| **Model configurations** | Unsafe parameters, content filter enforcement (provider-aware), disabled safety | ✅ |
+### Tool-centric diff model *(do this first — it is a schema change)*
+- ✅ Re-key capability snapshots on `(tool_identity, capability, access_mode)` instead of flat capability sets — `safeai/analysis/tool_identity.py` (path-independent keys), `tool_surface.py`, `capability_diff.py` (schema v2, per-tool).
+- ✅ Track access-mode transitions explicitly — `read-only → mutating` is a first-class escalation (ranked `none < read < write < mutate < execute`, with inference and severity caps).
+- ✅ Persist per-agent snapshots of capability, authority, autonomy, data reach and governance evidence per scan (`agent_snapshots`, `agent_tool_snapshots` v2).
+- ✅ Migration path for existing v1.3 registries — additive, forward-only `_MIGRATIONS` (1 → 2).
 
-**Framework adapters (15 total):**
+### PR escalation review
+- ✅ Detect and rank: new shell capability, filesystem write added, external HTTP/API access added, new MCP server bound, MCP read-only → mutation, human approval gate removed, memory scope expanded, new write-capable tool, new external destination — 14 `ESC_*` escalation rules in a data table with subsumption, `--fail-on-escalation`.
+- ✅ `--pr-comment` / `--pr-comment-stdout`: a short, grouped, reviewer-facing summary (never posted by SafeAI) — grouped by tool/server, leads with escalations, suppresses unchanged surface.
+- 🔄 Branch/base auto-detection — **GitHub Actions done**; GitLab CI and Azure Pipelines detection planned.
+- ✅ Risky-combination detection — untrusted input + shell, autonomous planning + broad access, delegation + external side effects (`ESC_COMBO_*`).
 
-| Tier | Frameworks |
-|------|-----------|
-| Earliest (v1.0) | LangGraph, CrewAI, LangChain, Semantic Kernel, OpenAI Agents SDK, Microsoft Agent, Azure AI Foundry, Bedrock Agent |
-| Phase 1.5 | Claude Code, Google ADK, Mastra, Haystack, LlamaIndex, Dify, n8n |
+### Surface depth *(the two that matter)*
+- 🔄 **Multi-source MCP discovery** — MCP servers discovered across the scanned repo and Claude Code configuration, normalised into one capability model with provenance on every entry. Cursor / Windsurf source scopes and user/global scopes are **not yet read** (out-of-repo scopes are intentionally behind an explicit gate and excluded from exports by default).
+- ✅ **Deep Claude Code analysis** — `.claude/settings.json`, instruction files, permissions, `allowedTools`, custom slash commands (treated as an injection surface), subagents, hooks, dangerous/auto-approve flags, project structure (10 `CC_*` rules; repo-local scope only, never user/machine config).
+- ✅ **MCP posture** — transport, authentication evidence, exposed tools and resources, wildcard permissions, local vs remote endpoint risk, configuration provenance.
 
-**Eight new capability detectors:** Docker, Kubernetes, Redis, S3, Slack, Jira, browser automation, GCP
+### Governance and lifecycle
+- 🔄 **Governed suppressions** — current suppressions already carry rule_id, file, location, reason, owner, expiry and are never silent. **Stale-suppression detection and CI failure when a waiver expires or code moves are planned.**
+- ⏳ **Per-finding lifecycle timeline** — introduced → resolved → reopened, with repeated reopening flagged as a governance signal.
+- 🔄 **Policy profiles** — policy-as-code shipped (`allow / warn / require_review / deny`); named profiles (`developer`, `strict-ci`, `mcp`, `rag`, `production-agent`) planned.
+- ✅ **Policy decision recorded on every scan** (pass / warn / review-required / block / accepted-exception, with rationale).
+- ⏳ **Registry freshness indicators** — never scanned, stale, changed since last approval, policy drift.
+- ⏳ **Locally enrichable agent metadata** — business owner, technical owner, intended purpose, environment, lifecycle status, review date.
 
-**Still planned in Phase 1.5:**
+### Trust and honesty
+- ✅ **Mandatory machine-readable assurance boundary block** in every report and manifest — what was verified (declared tools, prompt files, MCP servers, workflow structure, configuration) versus what cannot be verified statically (IAM permissions, runtime identity, deployed network policy, actual behaviour) — `assurance_boundary`.
+- ⏳ **Governance signal detection** — timeout, retry policy, approval workflow, audit logging, rate limiting.
+- ✅ **Better terminal output** — severity-grouped summary, clear layout, improved signal-to-noise (v1.4-b).
+- ✅ **Severity-weighted trust score** — 7-category weighted scoring keyed on `safeai/severity.py`.
 
-| Item | Status |
-|------|--------|
-| AutoGen framework adapter | Not yet implemented |
-| LangGraph conditional edge detection | Partially implemented — `add_edge` detected; `add_conditional_edges` not handled |
-| Governance detectors (timeout, retry, audit, rate limiting) | Not yet implemented |
-| Teams, SharePoint, OneDrive detection (MCP-based) | Deferred — requires MCP asset analysis expansion |
-| Split browser automation into separate rules (Playwright, Selenium, browser_use) | Under consideration |
-
----
-
-## Phase 2 — AI Security Testing (optional future)
-
-Runtime and dynamic analysis capabilities:
-
-- Runtime sandbox for safe execution of agent workflows
-- Hallucination and jailbreak testing
-- Prompt injection resilience testing
-- Goal hijacking detection
-- Tool misuse detection
-- Data exfiltration monitoring
-- Reliability and consistency testing
+### Exit criterion
+> ✅ **Achieved.** A reviewer sees, in a PR comment, that a specific **named tool** gained a specific **new authority** — and SafeAI records that change, the policy decision and the assurance boundary in local KYA history. Ordinary SAST does not produce that.
 
 ---
 
-## Phase 3 — Test Packs
+## CE 1.5 — True Capability Surface
 
-Curated test suites for compliance and security validation:
+*Goal: close the gap between what an agent declares and what it actually needs to run.*
 
-| Pack | Coverage |
-|------|----------|
-| OWASP LLM | OWASP Top 10 for LLM Applications |
-| Agent Security | Agent-specific threat patterns |
-| MCP Security | Model Context Protocol misconfiguration |
-| RAG Security | Retrieval-Augmented Generation risks |
-| Healthcare | HIPAA, patient data handling |
-| Finance | PCI, transaction security |
-| GDPR | Data protection, consent, right-to-deletion |
-| Custom | Organization-specific rule packs |
+**Status: ⏳ planned. Small overlaps do ship in the current analyzers; the items below are the planned surface.**
 
----
+- ⏳ **Secret and configuration dependency inventory** — `os.getenv`, `process.env`, `${VAR}`, `.env`, Kubernetes Secrets, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault — names and sources only, never values.
+- ⏳ **Dependency-to-capability correlation** — required credential with no matching declared tool = undeclared capability candidate; declared tool with no credential path = probable dead or misconfigured tool.
+- ⏳ **Tool → implementation mapping** — declaration site, implementation site, unresolved/orphan cases in both directions.
+- ⏳ **Command-aware MCP analysis** — resolve in-repo and vendored server entrypoints statically, depth-capped, never executed, with explicit resolved / unresolved-command labelling.
+- ⏳ **External write target taxonomy** — filesystem, databases, S3, blob storage, GitHub, Slack, external APIs — promoted to a first-class report view.
+- ⏳ **Heuristic data-flow depth** — untrusted input propagation into prompts and tool arguments.
+- ⏳ **Adapter completion** — AutoGen, LangGraph `add_conditional_edges`, browser-automation rule split (Playwright / Selenium / browser_use).
 
-## Phase 4 — Enterprise (Commercial)
-
-Scalability and management capabilities for enterprise adoption:
-
-- Fleet-wide scanning across repositories and projects
-- Central policy management with role-based access control
-- Trend analysis and risk dashboards over time
-- Enterprise integrations (Azure DevOps, GitLab, Jenkins, etc.)
-- Reporting dashboards with executive summaries
+### Exit criterion
+> SafeAI reports the credentials, destinations and implementations an agent actually depends on, and flags mismatches between declared and required capability — with no cloud access and no execution.
 
 ---
 
-## Phase 5 — Community Intelligence
+## CE 1.6 — AI Component Records
 
-Community-powered threat intelligence:
+*Goal: extend evidence from agents to the reusable components they share. Deliberately after 1.5.*
 
-- Reputation services for MCP servers, tools, and prompts
-- Known malicious prompts, skills, and MCP servers database
-- Community-shared detection rules
-- AI vulnerability database (curated from public sources)
-- Public risk intelligence feeds
+**Status: 🔄 partial. Component-level analysis ships today (skills, prompts, MCP configs, tool definitions, workflows, model configs); registry impact queries and component-change diffs are planned.**
+
+- ✅ Treat prompts, skills, MCP configurations, tool definitions, workflows and model configs as versioned components (component analysis → findings).
+- ✅ Scan only local and vendored artifacts — no external feeds.
+- ✅ Detect embedded prompts, hard-coded secrets, over-broad permissions, insecure defaults, unpinned references, unsafe composition.
+- ⏳ Record component identity, version/hash, source, findings and usage relationships in the local registry.
+- ⏳ **Impact queries** — which agents reference this MCP server, prompt template, tool definition or model config?
+- ⏳ **Component-change diffs** — a changed MCP configuration affects seven scanned agents.
+- ⏳ Component manifests where feasible; lockfile-style integrity metadata deferred to 2.x.
+
+### Exit criterion
+> A team can trace a risky reusable component to every consuming agent and repository, and produce static evidence for remediation.
+
+---
+
+## CE 2.0 — Ecosystem and Static Authority Correlation
+
+*Goal: grow coverage through contribution, and answer the authority question without leaving the repository.*
+
+**Status: 🔄 plugin architecture; the rest ⏳ planned.**
+
+### Ecosystem
+- 🔄 **Stable plugin SDK** — framework adapters, analyzers, and rules are already pluggable (entry-point + decorator discovery); report enrichers and policy packs planned.
+- ⏳ **Curated (and signed where practical) community registry** for versioned rule and policy packages.
+- ⏳ **`safeai init`** — config, local registry, recommended policy profile.
+- ⏳ **Custom rule authoring** with fixtures, tests, expected findings.
+- ⏳ **Control mappings** — OWASP Top 10 for Agentic Applications, OWASP Top 10 for LLM Applications, NIST AI RMF 1.0 (NIST AI 100-1) — presented as taxonomy, policy selection and prioritisation aid, explicitly **not** as coverage or compliance claims.
+- ⏳ Plugin and rule-pack versions recorded in every scan for reproducibility.
+- ⏳ **Portable registry export/import** so organisations can exchange KYA evidence without a central service.
+
+### Static authority correlation *(the community's Phase 3, offline)*
+- ⏳ Parse in-repo IaC — Terraform, CloudFormation, Helm, Kubernetes manifests, serverless configs.
+- ⏳ Compare declared capability against granted authority and report both directions: capability without grant (probable breakage), and grant without capability (excess authority).
+- ⏳ Report confidence honestly — IaC in the repo is not proof of what is deployed, and the assurance boundary block must say so.
+
+### Exit criterion
+> A contributor can add an adapter or rule pack with tests, and a reviewer can see declared-versus-granted authority mismatches using only files already in the repository.
+
+---
+
+## CE permanent guarantees
+
+- ✅ **Local by default** — no account, server, daemon, telemetry or external network calls.
+- ✅ **Source-private by default** — references and evidence, not raw source.
+- ✅ **Static truth only** — detected evidence always distinguished from unknown runtime state.
+- ✅ **No compliance certification claims** — mappings and evidence, never a declaration that an agent is safe or compliant.
+- ✅ **No runtime-platform creep in core** — no interception, sandboxing, identity issuance or production monitoring.
+
+---
+
+# Roadmap 2 — Corporate Edition (commercial evidence and governance plane)
+
+**Mission:** turn per-repository KYA evidence into organisational assurance — who owns which agent, what authority it holds, who approved it, and what changed since.
+
+**Status: ⏳ all milestones planned; architecture and sequencing defined below.**
+
+**Non-goals:** a second scanner, a runtime security platform, an observability product, a compliance certificate.
+
+**Architecture:** built entirely on `safeai-manifest.json` and portable registry exports produced by the free scanner. No privileged data path. Self-hosted first.
+
+## EE0 — Commercial foundation *(do before writing any Corporate feature)*
+Mindset: sequencing matters more than features — get it wrong and CE becomes unmonetisable or the contributor base walks.
+
+- Keep the core Apache 2.0 — do not relicense shipped code. Corporate lives in a separate repository or module under a proprietary or BSL licence (open-core, cleanly separated).
+- Contribution terms: a DCO or CLA in place **before** CE 2.0's plugin ecosystem attracts external contributions.
+- Publish the edition boundary and the never-gated list in the repository; say it once, publicly.
+- **Freeze the manifest contract** — version, document and schema-test `safeai-manifest.json` and the registry export format; it is the entire integration surface.
+- Protect the **SafeAI** name and the **KYA** positioning; keep "Know Your Agent" an operating principle, not a claimed standard.
+- Price on **agents or repositories under governance**, not seats; keep the free tier genuinely useful at small scale.
+
+## EE1 — Organisational Evidence Registry
+*The first thing to sell. Aggregation and ownership, not analytics.*
+- Self-hosted central registry of an org-wide KYA inventory from CI-submitted manifests and local exports.
+- Portfolio view across repositories, teams and environments; portfolio-level diffs.
+- Ownership model: business owner, technical owner, environment, lifecycle status, review date, approval state.
+- Central exception management: verified approver identity, approval workflow, expiry enforcement and notification, org-wide stale-waiver reporting (the identity-backed half of the Community CE 1.4 suppressions item).
+- PR risk ownership and security-review assignment routing.
+- SSO, RBAC, audit logs.
+- Registry coverage reporting: unscanned / stale / drifted repositories and agents.
+
+## EE2 — Policy Governance and Evidence Integrity
+- Private rule and policy registries, org-wide distribution and version pinning.
+- Central baseline management and approved-exception inheritance across repositories.
+- Signed attestations and tamper-evident, immutable scan evidence with retention controls.
+- Reproducibility guarantee per decision: exact scanner version, ruleset, policy and configuration hash.
+- Assurance-boundary declarations (from CE 1.4) carried into every attestation.
+- DevSecOps integrations: GitHub, GitLab, Azure DevOps, Jenkins, Jira, ServiceNow, SIEM, GRC, artifact stores.
+- Trend analysis and executive reporting — only once ownership, schemas and workflow are stable.
+
+## EE3 — Live Authority Reconciliation
+*The highest-value corporate capability, and the reason the edition boundary exists.*
+- Read-only reconciliation of declared capability against live granted authority: AWS IAM, Azure Managed Identity, GCP IAM, Kubernetes RBAC, service accounts, network policies.
+- Continuous drift detection between approved baseline authority and current deployed authority.
+- Cross-environment comparison (dev / staging / prod divergence).
+- Optional runtime-evidence correlation: link static finding IDs to observed behaviour from existing runtime/observability tools, presented as correlated evidence, never as static-scan evidence.
+- Capability-informed test-plan export to third-party evaluation, red-team and runtime-governance tools, with results linked to the exact scan and policy decision.
+- Delivered as a separate explicitly installed component with scoped read-only credentials — never inside the core scanner, so the offline guarantee holds.
+
+## EE4 — Regulated-Industry Content and Federation
+- Maintained compliance-oriented policy and rule packs: HIPAA/patient data, PCI/transaction security, GDPR/data protection, EU AI Act mappings, org-specific packs.
+- Control-mapped evidence exports for GRC and audit workflows, with explicit non-certification language.
+- Optional federated registry — safe KYA evidence across business groups without centralising source code.
+- Optional opt-in intelligence services (component reputation, known-malicious component data) — network-dependent by nature, therefore Corporate-only and always opt-in.
+
+---
+
+## Registry of latest shipped work (this branch, see CHANGELOG/releases)
+
+- **v1.4-b** — unified **org-wide shared registry** (`SAFEAI_REGISTRY` env var or `~/.safeai/registry.db`), self-contained **HTML reports** for scan and registry output, docs aligned to the v1.4 capability model.
+- **v1.4** — tool-centric capability model + access modes, 14 declarative escalation rules with subsumption, per-tool capability diff, deep **Claude Code** analysis, **PR comment** review output, **assurance boundary**, governed suppressions policy-as-code, severity centralization (`safeai/severity.py`), KYA registry schema v2 migration.
+- **Architecture refactor (P1)** — `safeai/kya/registry` split into `schema/connection/persist/queries`, `ScanOrchestrator` extracted from `run_scan`, `ScanPostProcessor` extracted from the scan CLI command. No public API break.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ SafeAI is a **Static AI Capability & Risk Analyzer** — think SonarQube for AI 
 
 This document describes the roadmap across **two editions**: the open-source **Community Edition (Apache 2.0, offline, local-first)** and the commercial **Corporate Edition (evidence and governance plane)**. Milestones are not strictly sequential; work may proceed in parallel where dependencies allow.
 
-> **Current state:** v1.4-b shipped. Community Edition **CE 1.4 (Reviewable Change)** is substantially complete; planned work there is limited to a handful of governance and surface items. CE 1.5/1.6/2.0 and the entire Corporate Edition are planned.
+> **Current state:** v1.4-b shipped; CE 1.5 environment-inventory and dependency-correlation work is in progress on this branch. Community Edition **CE 1.4 (Reviewable Change)** is substantially complete; CE 1.5/1.6/2.0 and the entire Corporate Edition are planned.
 
 ---
 
@@ -64,10 +64,10 @@ Status legend: ✅ **Shipped** · 🔄 **In progress / partial** · ⏳ **Planne
 
 *Goal: close the gap between what an agent declares and what it actually needs to run.*
 
-**Status: ⏳ planned. Small overlaps do ship in the current analyzers; the items below are the planned surface.**
+**Status: 🔄 partial — CE 1.5 environment inventory and correlation shipped; remaining surface items planned below.**
 
-- ⏳ **Secret and configuration dependency inventory** — `os.getenv`, `process.env`, `${VAR}`, `.env`, Kubernetes Secrets, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault — names and sources only, never values.
-- ⏳ **Dependency-to-capability correlation** — required credential with no matching declared tool = undeclared capability candidate; declared tool with no credential path = probable dead or misconfigured tool.
+- ✅ **Secret and configuration dependency inventory** — names and sources only, never values: `os.getenv`, `os.environ`, `process.env`, dotenv keys, shell/template interpolation, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault, Kubernetes `secretKeyRef` (`safeai/analyzers/env_dependency`).
+- ✅ **Dependency-to-capability correlation** — referenced credential/config with no matching declared capability = undeclared-capability candidate; declared credential-demanding capability with no referenced config = orphaned tool (`safeai/analysis/dependency_correlation.py`, rules `DEP_*`). Correlation findings feed severity, trust score, SARIF, HTML and the manifest. Matching uses whole-word-segment family keywords (no substring false positives on `jdbc`/`rabbit_mq`), with provider families taking precedence over the generic `api` fallback; the payload-carrying `ENV_DEP_INVENTORY` finding is exempt from suppression so the inventory section can never be blanked.
 - ⏳ **Tool → implementation mapping** — declaration site, implementation site, unresolved/orphan cases in both directions.
 - ⏳ **Command-aware MCP analysis** — resolve in-repo and vendored server entrypoints statically, depth-capped, never executed, with explicit resolved / unresolved-command labelling.
 - ⏳ **External write target taxonomy** — filesystem, databases, S3, blob storage, GitHub, Slack, external APIs — promoted to a first-class report view.
@@ -75,7 +75,7 @@ Status legend: ✅ **Shipped** · 🔄 **In progress / partial** · ⏳ **Planne
 - ⏳ **Adapter completion** — AutoGen, LangGraph `add_conditional_edges`, browser-automation rule split (Playwright / Selenium / browser_use).
 
 ### Exit criterion
-> SafeAI reports the credentials, destinations and implementations an agent actually depends on, and flags mismatches between declared and required capability — with no cloud access and no execution.
+> SafeAI reports the credentials and destinations an agent actually depends on, and flags mismatches between declared and required capability — with no cloud access and no execution.
 
 ---
 
@@ -191,6 +191,7 @@ Mindset: sequencing matters more than features — get it wrong and CE becomes u
 
 ## Registry of latest shipped work (this branch, see CHANGELOG/releases)
 
+- **CE 1.5 (in progress)** — environment & credential dependency inventory (`os.getenv`/`os.environ`/`process.env`/dotenv/shell/template, AWS Secrets Manager, Azure Key Vault, GCP Secret Manager, HashiCorp Vault, Kubernetes `secretKey` — names and sources only, never values) and dependency-to-capability correlation (`DEP_UNDECLARED_CAPABILITY`, `DEP_ORPHANED_TOOL`), surfaced in terminal, HTML, SARIF, and the KYA manifest (`dependency_inventory`, `dependency_correlation`) with a reviewable name-family heuristic.
 - **v1.4-b** — unified **org-wide shared registry** (`SAFEAI_REGISTRY` env var or `~/.safeai/registry.db`), self-contained **HTML reports** for scan and registry output, docs aligned to the v1.4 capability model.
 - **v1.4** — tool-centric capability model + access modes, 14 declarative escalation rules with subsumption, per-tool capability diff, deep **Claude Code** analysis, **PR comment** review output, **assurance boundary**, governed suppressions policy-as-code, severity centralization (`safeai/severity.py`), KYA registry schema v2 migration.
 - **Architecture refactor (P1)** — `safeai/kya/registry` split into `schema/connection/persist/queries`, `ScanOrchestrator` extracted from `run_scan`, `ScanPostProcessor` extracted from the scan CLI command. No public API break.

--- a/safeai/analysis/dependency_correlation.py
+++ b/safeai/analysis/dependency_correlation.py
@@ -1,0 +1,253 @@
+"""Dependency-to-capability correlation (CE 1.5).
+
+Answers two questions that the capability analyzer cannot answer alone:
+
+1. **Undeclared dependency** — a credential/config name is referenced but no
+   declared tool or capability plausibly consumes it. Static evidence that the
+   agent reaches past its declared surface — a candidate undeclared capability.
+2. **Orphaned declared tool** — a tool/capability that by nature needs a
+   credential or backing service (database, cloud, API) has no matching
+   dependency or config reference anywhere in the repository. Usually dead or
+   misconfigured.
+
+Both combine static evidence already in the report. Nothing executes code,
+reads a secret, or verifies runtime behaviour — results are labelled heuristic
+correlations, consistent with the assurance boundary.
+
+Matching uses name-family keyword tables below, kept reviewable rather than
+data-driven. Weak correlations stay silent.
+"""
+
+import re
+
+#: Correlation finding rule ids.
+RULE_UNDECLARED = "DEP_UNDECLARED_CAPABILITY"
+RULE_ORPHAN = "DEP_ORPHANED_TOOL"
+
+#: Keyword families map names to a capability family. A name matches only when
+#: a token occurs as a whole word/segment (see ``_parse_words``), never as a
+#: bare substring — this avoids false positives like ``jdbc`` -> database (via
+#: ``db``) or ``rabbit_mq`` strings that merely contain a short token.
+#:
+#: Precedence is provider-specific first, generic ``api`` last. This keeps a
+#: ``SLACK_TOKEN`` (provider ``slack`` -> messaging) aligned with a declared
+#: ``slack`` capability instead of being pulled into ``api`` by its ``token``
+#: suffix — the prior order produced simultaneous false undeclared + orphan.
+_FAMILIES = (
+    ("cloud", ("aws", "azure", "gcp", "google", "s3")),
+    ("database", ("database", "postgres", "mysql", "sql", "redis", "mongo",
+                  "oracle", "mssql", "maria", "sqlite")),
+    ("messaging", ("slack", "kafka", "rabbit", "sqs", "pubsub")),
+    ("api", ("api", "http", "url", "endpoint", "key", "token", "secret",
+             "auth", "client", "openai", "anthropic", "gemini", "claude",
+             "ollama", "vertex")),
+)
+
+#: Families whose declared tools need backing config or credentials. Only
+#: these drive orphan detection (avoid flagging stateless tools). ``api`` is
+#: intentionally excluded — generic HTTP/external APIs are matched against a
+#: declared capability and should not be re-flagged.
+_CREDENTIAL_DEMANDING = {"cloud", "database", "messaging"}
+
+#: Capability family derived from the capability name — same vocabulary as
+#: ``_FAMILIES`` so declared and referenced sides compare on a shared axis.
+_CAP_FAMILY = {
+    "s3": "cloud",
+    "cloud": "cloud",
+    "kubernetes": "cloud",
+    "gcp": "cloud",
+    "docker": "cloud",
+    "databases": "database",
+    "db": "database",
+    "redis": "database",
+    "external_apis": "api",
+    "http": "api",
+    "slack": "messaging",
+    "jira": "api",
+    "filesystem": "filesystem",
+    "file_write": "filesystem",
+}
+
+
+def _parse_words(key):
+    """Split a name into whole lowercase word segments.
+
+    Breaks on non-alphanumeric characters (``_``, ``.``, ``-``, spaces) so
+    ``AWS_SECRET_ACCESS_KEY`` -> ``{"aws", "secret", "access", "key"}``. This
+    guarantees segment-exact matching (``db`` never matches ``jdbc``).
+    """
+    return {w for w in re.split(r"[^A-Za-z0-9]+", key) if w}
+
+
+def _family_via_tokens(key, table):
+    words = _parse_words(key)
+    for prop, tokens in table:
+        if any(token in words for token in tokens):
+            return prop
+    return None
+
+
+def family_of_capability(name):
+    """Return the correlation family of a declared capability name, or None."""
+    key = str(name or "").lower()
+    if key in _CAP_FAMILY:
+        return _CAP_FAMILY[key]
+    return _family_via_tokens(key, _FAMILIES)
+
+
+def family_of_config(name):
+    """Return the family of a referenced config/credential name, or None."""
+    key = str(name or "").lower()
+    return _family_via_tokens(key, _FAMILIES)
+
+
+def _cap_name(entry):
+    if isinstance(entry, dict):
+        return entry.get("name")
+    return str(entry)
+
+
+def _gather_declared(report):
+    """Collect declared capability families from the report.
+
+    Uses the tool_surface (v1.4 attribution) when present, else normalized
+    capabilities. Returns (set of families, dict family -> set of tool keys).
+    """
+    families = set()
+    by_family = {}
+    surface = report.get("tool_surface")
+    if surface:
+        tools = surface if isinstance(surface, list) else surface.get("tools") or []
+        for entry in tools:
+            tool_key = entry.get("tool_key") or entry.get("name")
+            caps = entry.get("capabilities") or []
+            for cap in caps:
+                fam = family_of_capability(_cap_name(cap))
+                if fam:
+                    families.add(fam)
+                    by_family.setdefault(fam, set()).add(str(tool_key))
+        return families, by_family
+
+    for cap in report.get("normalized_capabilities") or []:
+        fam = family_of_capability(_cap_name(cap))
+        if fam:
+            families.add(fam)
+    return families, by_family
+
+
+def _inventory_from_report(report):
+    """Return the env-dependency inventory carried by the scan report."""
+    for finding in report.get("findings") or []:
+        if finding.get("rule_id") == "ENV_DEP_INVENTORY":
+            return finding.get("dep_inventory") or []
+    return []
+
+
+def _inventory_family_map(inventory):
+    """Map family -> list of inventory entries for that family."""
+    fam_map = {}
+    for entry in inventory:
+        fam = family_of_config(entry.get("name"))
+        if fam:
+            fam_map.setdefault(fam, []).append(entry)
+    return fam_map
+
+
+def correlate_dependencies(report):
+    """Correlate the dependency inventory against the declared capability
+    surface.
+
+    Returns ``(findings, summary)``. Findings target DEP_UNDECLARED_CAPABILITY
+    and DEP_ORPHANED_TOOL, ready for the post-scan pipeline. summary carries
+    the correlation model and per-family counts for report rendering.
+    """
+    inventory = _inventory_from_report(report)
+    declared_families, declared_by_family = _gather_declared(report)
+    referenced = _inventory_family_map(inventory)
+
+    findings = []
+    counts = {"families": {}, "undeclared": 0, "orphaned": 0}
+
+    # 1. Undeclared capability candidates — referenced config/credential
+    #    family with no declared capability to consume it.
+    for fam in sorted(referenced):
+        entries = referenced[fam]
+        consumed = fam in declared_families
+        counts["families"][fam] = {
+            "referenced": len(entries),
+            "declared": consumed,
+        }
+        if consumed:
+            continue
+        entry = entries[0]
+        source = (entry.get("sources") or [{}])[0]
+        names = sorted({e.get("name") for e in entries})
+        findings.append({
+            "rule_id": RULE_UNDECLARED,
+            "severity": "medium",
+            "message": "Referenced credential/config has no matching declared capability",
+            "file": source.get("file", "<scan>"),
+            "line": source.get("line", 1),
+            "owasp_llm": "LLM02",
+            "evidence": f"family={fam} names={', '.join(names[:4])}",
+            "reason": (
+                f"Configuration/credential family '{fam}' is referenced "
+                f"({len(entries)} name(s)) but no declared tool or capability "
+                "in this family was found; this is a likely undeclared capability."
+            ),
+            "risk_category": "Identity",
+            "affected_framework": "generic",
+            "affected_capability": "Environment",
+            "score_contribution": 6,
+            "remediation": (
+                "Confirm the referenced credential/config is consumed by a declared "
+                "tool or capability; add the declaration or remove the orphaned reference."
+            ),
+            "confidence": 0.6,
+            "dependency_family": fam,
+            "dependency_names": names,
+        })
+        counts["undeclared"] += 1
+
+    # 2. Orphaned declared tool — a credential-demanding family is declared
+    #    but no matching config/credential is referenced anywhere.
+    for fam in sorted(declared_families):
+        if fam not in _CREDENTIAL_DEMANDING:
+            continue
+        if fam in referenced:
+            continue
+        tool_keys = sorted(declared_by_family.get(fam, ()))
+        findings.append({
+            "rule_id": RULE_ORPHAN,
+            "severity": "low",
+            "message": "Declared capability lacks a matching credential/config",
+            "file": "<scan>",
+            "line": 1,
+            "owasp_llm": "LLM06",
+            "evidence": f"family={fam} tools={', '.join(tool_keys) or 'unknown'}",
+            "reason": (
+                f"Capability family '{fam}' requires a credential, service, or backend "
+                "configuration, but no matching environment variable, secret-manager "
+                "entry, or config reference was found; the tool may be dead or misconfigured."
+            ),
+            "risk_category": "Integration",
+            "affected_framework": "generic",
+            "affected_capability": fam,
+            "score_contribution": 3,
+            "remediation": (
+                "Verify the capability is real: add the expected credential/config "
+                "reference, or remove the stale tool declaration."
+            ),
+            "confidence": 0.5,
+            "dependency_family": fam,
+        })
+        counts["orphaned"] += 1
+
+    findings.sort(key=lambda f: (f.get("file", ""), int(f.get("line") or 0), f.get("rule_id", "")))
+    return findings, {
+        "schema_version": 1,
+        "correlation_model": "name-family keyword families",
+        "counts": counts,
+        "referenced_families": sorted(referenced),
+        "declared_families": sorted(declared_families),
+    }

--- a/safeai/analyzers/env_dependency/__init__.py
+++ b/safeai/analyzers/env_dependency/__init__.py
@@ -1,0 +1,10 @@
+"""Environment and credential dependency inventory (CE 1.5).
+
+Detects *references* to configuration and credential sources — names and
+source locations only, never values. SafeAI records that an agent depends
+on ``DATABASE_URL`` or an AWS Secrets Manager entry, not what the value is.
+"""
+
+from safeai.analyzers.env_dependency.analyzer import EnvDependencyAnalyzer
+
+__all__ = ["EnvDependencyAnalyzer"]

--- a/safeai/analyzers/env_dependency/analyzer.py
+++ b/safeai/analyzers/env_dependency/analyzer.py
@@ -1,0 +1,202 @@
+"""Environment and credential dependency inventory analyzer.
+
+Scans source and configuration for *references* to external configuration:
+environment variables, ``.env`` files, secret-manager lookups, Kubernetes
+Secrets, and cloud vault providers.
+
+Critical constraint — **names and sources only, never values.** SafeAI records
+that an agent depends on ``DATABASE_URL`` (``os.getenv("DATABASE_URL")`` at
+``app.py:12``), not any value it could hold. This keeps the inventory useful
+for correlation while preserving the project's existing source-private,
+no-raw-secret guarantee.
+
+The analyzer emits one carrying finding (``ENV_DEP_INVENTORY``) that
+orchestration uses to attach the inventory to the report, mirroring the
+MCP ``MCP_ASSETS_DISCOVERED`` pattern. No inventory entry ever contains a
+user-facing value.
+"""
+
+import re
+
+INVENTORY_RULE_ID = "ENV_DEP_INVENTORY"
+
+#: Python ``os.getenv(...)`` / ``os.environ[...]`` / ``os.environ.get(...)``.
+_OS_GETENV_RE = re.compile(
+    r"\bos\.(?:environ\.get|getenv)\s*\(\s*[\"']([A-Za-z_][A-Za-z0-9_.-]*)[\"']",
+    re.IGNORECASE,
+)
+_OS_ENVIRON_RE = re.compile(
+    r"\bos\.environ\s*\[\s*[\"']([A-Za-z_][A-Za-z0-9_.-]*)[\"']\s*\]",
+    re.IGNORECASE,
+)
+
+#: Node ``process.env.X`` references.
+_PROCESS_ENV_RE = re.compile(
+    r"\bprocess\.env(?:\.([A-Za-z_][A-Za-z0-9_]*)|\[\s*[\"']([A-Za-z_][A-Za-z0-9_.-]*)[\"']\s*\])"
+)
+
+#: Shell ``${VAR}`` / ``$VAR`` interpolation.
+_SHELL_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$(?![0-9])([A-Za-z_][A-Za-z0-9_]*)")
+
+#: Jinja / dot-template ``{{ env('X') }}``.
+_JINJA_ENV_RE = re.compile(r"\{\{\s*env\s*\(\s*['\"]([A-Za-z_][A-Za-z0-9_.-]*)['\"]\s*\)\s*\}\}")
+
+#: ``.env``-style ``KEY=value`` lines.
+_DOTENV_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*=")
+
+#: AWS Secrets Manager ``get_secret_value(SecretId="...")``.
+_AWS_SECRET_RE = re.compile(
+    r"\b(?:get_secret_value|GetSecretValue)\s*\(\s*['\"]?([A-Za-z_][A-Za-z0-9_\-/.]*)['\"]?",
+    re.IGNORECASE,
+)
+
+#: Azure Key Vault ``SecretClient(...)`` / ``get_secret("...")``.
+_AZURE_VAULT_RE = re.compile(
+    r"\b(?:SecretClient|get_secret)\s*\([^)]*?['\"]?([A-Za-z_][A-Za-z0-9_\-/.]*)['\"]?",
+    re.IGNORECASE,
+)
+
+#: GCP Secret Manager.
+_GCP_SECRET_RE = re.compile(
+    r"\b(?:secretmanager|access_secret_version)\b[^\"']*[\"']([A-Za-z0-9_\-/.]{3,})[\"']",
+    re.IGNORECASE,
+)
+
+#: HashiCorp Vault reads.
+_VAULT_RE = re.compile(
+    r"\b(?:vault\.read|hvac\.|\.read_secret)\s*\([^)]*?[\"']([A-Za-z_][A-Za-z0-9_\-/.]*)[\"']",
+    re.IGNORECASE,
+)
+
+#: Kubernetes ``secretKeyRef.name`` / ``secretRef.name`` in manifests
+#: (brace or same-line block form; multi-line YAML is handled by the name
+#: keyword heuristics via ``mark_secret_name``).
+_K8S_SECRET_RE = re.compile(
+    r"\b(?:secretKeyRef|secretRef)\s*:\s*(?:\{[^}]*?\bname\s*:\s*([A-Za-z_][A-Za-z0-9_\-.]*)|\s*([A-Za-z_][A-Za-z0-9_\-.]*))",
+    re.IGNORECASE,
+)
+
+#: Secret-ish name keywords used to flag an entry as credential-backed even
+#: when it comes from an env var (e.g. ``AWS_SECRET_ACCESS_KEY``).
+_SECRET_NAME_TOKENS = ("secret", "token", "password", "_key", "credential", "passwd", "api_key")
+
+
+def _is_secret_name(name):
+    low = str(name or "").lower()
+    return any(tok in low for tok in _SECRET_NAME_TOKENS)
+
+#: Files whose path or name marks them as dotenv-style load points.
+DOTENV_MARKERS = (".env", "dotenv", "create_env", "load_env")
+
+
+def analyze_file_inventory(path, content):
+    """Collect credential/config names referenced in a single file.
+
+    Returns a list of dicts ``{"name", "detector", "line"}``. Only the name
+    and location are captured; no value is ever returned.
+    """
+    refs = []
+    is_dotenv = any(m in str(path).replace("\\", "/").lower() for m in DOTENV_MARKERS)
+
+    for i, line in enumerate(content.splitlines(), 1):
+        for match in _OS_GETENV_RE.finditer(line):
+            refs.append({"name": match.group(1), "detector": "os.getenv", "line": i})
+        for match in _OS_ENVIRON_RE.finditer(line):
+            refs.append({"name": match.group(1), "detector": "os.environ", "line": i})
+        for match in _PROCESS_ENV_RE.finditer(line):
+            name = match.group(1) or match.group(2)
+            if name:
+                refs.append({"name": name, "detector": "process.env", "line": i})
+        for match in _SHELL_VAR_RE.finditer(line):
+            name = match.group(1) or match.group(2)
+            if name:
+                refs.append({"name": name, "detector": "shell", "line": i})
+        for match in _JINJA_ENV_RE.finditer(line):
+            refs.append({"name": match.group(1), "detector": "template", "line": i})
+        for match in _AWS_SECRET_RE.finditer(line):
+            name = match.group(1)
+            if name and len(name) >= 2:
+                refs.append({"name": name, "detector": "aws_secrets", "line": i})
+        for match in _AZURE_VAULT_RE.finditer(line):
+            name = match.group(1)
+            if name and len(name) >= 2:
+                refs.append({"name": name, "detector": "azure_keyvault", "line": i})
+        for match in _GCP_SECRET_RE.finditer(line):
+            refs.append({"name": match.group(1), "detector": "gcp_secret", "line": i})
+        for match in _VAULT_RE.finditer(line):
+            refs.append({"name": match.group(1), "detector": "vault", "line": i})
+        for match in _K8S_SECRET_RE.finditer(line):
+            name = match.group(1) or match.group(2)
+            if name:
+                refs.append({"name": name, "detector": "k8s_secret", "line": i})
+
+        # .env style lines: record only the key.
+        if is_dotenv:
+            dotenv = _DOTENV_RE.match(line)
+            if dotenv:
+                key = dotenv.group(1)
+                if key:
+                    refs.append({"name": key, "detector": "dotenv", "line": i})
+
+    return refs
+
+
+class EnvDependencyAnalyzer:
+    """Detects references to external configuration and credentials."""
+
+    name = "env_dependency"
+
+    def run(self, file_cache, rules, agent_models=None):
+        """Return a carrying ``ENV_DEP_INVENTORY`` finding with the inventory.
+
+        Entries dedupe by name across files; each carries its source
+        locations. Secret-manager-backed names are flagged ``secret=True``
+        for the correlation step.
+        """
+        by_name = {}
+
+        for path, content in file_cache.items():
+            for ref in analyze_file_inventory(path, content):
+                name = ref["name"]
+                if not name:
+                    continue
+                entry = by_name.get(name)
+                if entry is None:
+                    entry = {"name": name, "sources": []}
+                    by_name[name] = entry
+                source = {"file": path, "line": ref["line"], "detector": ref["detector"]}
+                if source not in entry["sources"]:
+                    entry["sources"].append(source)
+
+        inventory = []
+        secret_detectors = {"aws_secrets", "azure_keyvault", "gcp_secret", "vault", "k8s_secret"}
+        for name in sorted(by_name):
+            entry = by_name[name]
+            detectors = {s["detector"] for s in entry["sources"]}
+            entry["secret"] = bool(detectors & secret_detectors) or _is_secret_name(name)
+            entry["source_count"] = len(entry["sources"])
+            entry["sources"] = sorted(entry["sources"], key=lambda s: (s["file"], s["line"]))
+            inventory.append(entry)
+
+        return _wrap_inventory(inventory, rules)
+
+
+def _wrap_inventory(inventory, rules):
+    rule_map = {r.get("id"): r for r in (rules or [])}
+    rule = rule_map.get(INVENTORY_RULE_ID, {})
+    return [{
+        "rule_id": INVENTORY_RULE_ID,
+        "severity": rule.get("severity", "info"),
+        "message": f"Referenced {len(inventory)} external configuration/credential names",
+        "file": "<scan>",
+        "line": 1,
+        "owasp_llm": rule.get("owasp_llm", "LLM02"),
+        "evidence": f"env-dependency inventory size={len(inventory)}",
+        "reason": "Credential and config inventory gathered for dependency-to-capability correlation.",
+        "risk_category": "Identity",
+        "affected_framework": "generic",
+        "affected_capability": "Environment",
+        "score_contribution": 0,
+        "remediation": "Confirm each referenced configuration/credential maps to a declared tool or capability; revise orphaned tools.",
+        "dep_inventory": inventory,
+    }]

--- a/safeai/engine/orchestrator.py
+++ b/safeai/engine/orchestrator.py
@@ -35,6 +35,7 @@ from safeai.analysis.tool_surface import build_tool_surface
 from safeai.analyzers.capability.analyzer import CapabilityAnalyzer
 from safeai.analyzers.claude_code.analyzer import ClaudeCodeAnalyzer
 from safeai.analyzers.data_leakage.analyzer import DataLeakageAnalyzer
+from safeai.analyzers.env_dependency.analyzer import EnvDependencyAnalyzer
 from safeai.analyzers.mcp.analyzer import MCPAnalyzer
 from safeai.analyzers.prompt.analyzer import PromptAnalyzer
 from safeai.frameworks import discover_parsers
@@ -278,6 +279,8 @@ class ScanOrchestrator:
         self.findings = []
         self.mcp_assets = []
         self.mcp_capabilities = []
+        self.env_inventory = []
+        self.dependency_correlation = None
         self.counts = {}
         self.trust_score = {}
         self.project_graph = {}
@@ -375,6 +378,7 @@ class ScanOrchestrator:
             CapabilityAnalyzer(),
             PromptAnalyzer(),
             DataLeakageAnalyzer(),
+            EnvDependencyAnalyzer(),
             MCPAnalyzer(),
             ClaudeCodeAnalyzer(),
         ]
@@ -426,12 +430,24 @@ class ScanOrchestrator:
                 self.counts[sev] = 0
             self.counts[sev] += 1
 
+    def _extract_env_inventory(self):
+        """Extract the env-dependency inventory from the carrying finding."""
+        self.env_inventory = []
+        for finding in self.findings:
+            if finding.get("rule_id") == "ENV_DEP_INVENTORY":
+                self.env_inventory = finding.get("dep_inventory") or []
+        return self.env_inventory
+
     def _relativize_report(self):
         # Normalize all paths in the report to be relative to the scanned
         # root so reports are portable and SARIF consumers (e.g. GitHub
         # code scanning) can map results back to repository files.
         for finding in self.findings:
             finding["file"] = _relativize(finding.get("file"), self.directory)
+        # Relativize inventory source locations (paths only, never values).
+        for entry in self.env_inventory:
+            for source in entry.get("sources") or []:
+                source["file"] = _relativize(source.get("file"), self.directory)
         for model in self.agent_models:
             model["file"] = _relativize(model.get("file"), self.directory)
         for entry in self.parse_provenance:
@@ -446,11 +462,15 @@ class ScanOrchestrator:
             diagnostic["file"] = _relativize(diagnostic.get("file"), self.directory)
 
     def assemble(self):
-        """Stage 6: score, relativize paths, build the final report document."""
+        """Stage 6: correlate, build the tool surface, then a single
+        score/relativize pass over the final finding set.
+
+        Correlation (CE 1.5) must run before scoring so its findings are
+        included in counts, the trust score, and path relativization —
+        exactly once, avoiding a second pass over already-relativized data.
+        """
         self._extract_mcp_assets()
-        self._count_severities()
-        self.trust_score = score_report(self.findings)
-        self._relativize_report()
+        self._extract_env_inventory()
         self.project_graph = build_project_graph(
             self.agent_models, mcp_assets=self.mcp_assets, components=self.components
         )
@@ -483,8 +503,36 @@ class ScanOrchestrator:
         }
         # Per-tool capability surface (v1.4): the unit the diff compares and
         # the registry persists. Built from report data only — no extra file
-        # access.
+        # access. Requires only agent_models/mcp_assets, so it runs before
+        # scoring/counting below.
         self.report["tool_surface"] = build_tool_surface(self.report)
+        # Dependency-to-capability correlation (CE 1.5): match the
+        # env-dependency inventory against the declared tool surface. Findings
+        # are appended BEFORE the single count/score/relativize pass so they
+        # participate in severities, trust score, and path normalisation.
+        from safeai.analysis.dependency_correlation import correlate_dependencies
+
+        correlation_findings, self.dependency_correlation = correlate_dependencies(self.report)
+        if correlation_findings:
+            for finding in correlation_findings:
+                finding["file"] = _relativize(finding.get("file"), self.directory)
+                self.findings.append(finding)
+            self.findings.sort(key=lambda f: (
+                str(f.get("file") or ""),
+                int(f.get("line") or 0),
+                str(f.get("rule_id") or ""),
+            ))
+            self.report["findings"] = self.findings
+
+        self.report["dependency_inventory"] = self.env_inventory
+        self.report["dependency_correlation"] = self.dependency_correlation
+        # Single pass: counts, trust score, and relative paths, all over the
+        # complete finding set (core + component + correlation).
+        self._count_severities()
+        self.trust_score = score_report(self.findings)
+        self.report["counts"] = self.counts
+        self.report["trust_score"] = self.trust_score
+        self._relativize_report()
         # Assurance boundary (v1.4): what this scan did and did not verify.
         # Derived from the run itself, never a fixed disclaimer string.
         self.report["assurance_boundary"] = build_assurance_boundary(self.report)

--- a/safeai/kya/enrich.py
+++ b/safeai/kya/enrich.py
@@ -30,6 +30,8 @@ _ANALYZER_BY_RULE_PREFIX = {
     "PROMPT_FILE_": "prompt_file",
     "PROMPT_": "prompt",
     "DATA_LEAKAGE": "data_leakage",
+    "ENV_DEP_": "env_dependency",
+    "DEP_": "env_dependency",
     "MCP_": "mcp",
     "SKILL_": "skill",
     "TOOL_DEF_": "tool_def",

--- a/safeai/kya/manifest.py
+++ b/safeai/kya/manifest.py
@@ -140,6 +140,19 @@ def build_manifest(report, *, project, scan_meta, safeai_meta, agents,
             }
             for c in (report.get("components") or [])
         ],
+        # CE 1.5: referenced external config/credential names (never values).
+        "dependency_inventory": [
+            {
+                "name": e.get("name"),
+                "secret": bool(e.get("secret")),
+                "source_count": e.get("source_count", 0),
+                "sources": [
+                    {"path": normalize_path(s.get("file")), "line": int(s.get("line") or 0)}
+                    for s in (e.get("sources") or [])
+                ],
+            }
+            for e in (report.get("dependency_inventory") or [])
+        ],
         "findings": findings,
         "summary": {
             "risk_score": trust.get("overall_ai_risk_score"),
@@ -147,6 +160,7 @@ def build_manifest(report, *, project, scan_meta, safeai_meta, agents,
             "capability_counts": _capability_counts(agents, report),
             "agent_count": len(agents),
             "component_count": len(report.get("components") or []),
+            "dependency_count": len(report.get("dependency_inventory") or []),
             "policy_decision": policy_decision or {"outcome": "warn", "reasons": ["No policy file supplied; default posture."]},
         },
         # v1.2: the assurance boundary states what this scan verified and

--- a/safeai/kya/suppressions.py
+++ b/safeai/kya/suppressions.py
@@ -21,6 +21,12 @@ import yaml
 
 DEFAULT_SUPPRESSIONS_PATH = os.path.join(".safeai", "suppressions.yml")
 
+#: Findings that carry structural payloads (inventories, asset lists) consumed
+#: by reports and downstream correlation. They are informational carriers, not
+#: security verdicts, so they are never suppressed — a broad ``rule_id`` or
+#: ``path`` suppression must not be able to blank the inventory section.
+_CARRYING_RULE_IDS = frozenset({"ENV_DEP_INVENTORY", "MCP_ASSETS_DISCOVERED"})
+
 _REQUIRED_FIELDS = ("reason", "owner", "created")
 
 
@@ -124,6 +130,8 @@ def apply_suppressions(findings, entries):
     applied = []
     suppressed_count = 0
     for finding in findings:
+        if finding.get("rule_id") in _CARRYING_RULE_IDS:
+            continue
         for entry in entries:
             if entry.get("expired"):
                 continue

--- a/safeai/report/html.py
+++ b/safeai/report/html.py
@@ -73,6 +73,62 @@ def _escalation_section(report):
     <p class='muted'>Highest escalation: {escape(str(highest or 'none'))}</p>"""
 
 
+def _dependency_section(report):
+    """Render the CE 1.5 dependency inventory + correlation summary."""
+    inventory = report.get("dependency_inventory") or []
+    correlation = report.get("dependency_correlation") or {}
+    if not inventory and not correlation:
+        return ""
+    parts = []
+
+    if inventory:
+        rows = [
+            [
+                escape(str(e.get("name", ""))),
+                "Yes" if e.get("secret") else "No",
+                str(e.get("source_count", 0)),
+                ", ".join(
+                    f"{escape(str(s.get('file', '')))}:{s.get('line', '')}"
+                    for s in (e.get("sources") or [])[:3]
+                ) or "-",
+            ]
+            for e in inventory
+        ]
+        parts.append(html_kit.data_table(
+            ["Name", "Secret-backed", "Refs", "Sources"],
+            rows,
+            empty="No external configuration/credential references detected.",
+        ))
+
+    counts = correlation.get("counts") or {}
+    undeclared = counts.get("undeclared", 0)
+    orphaned = counts.get("orphaned", 0)
+    families = counts.get("families") or {}
+    fam_rows = [
+        [escape(str(fam)), str(info.get("referenced", 0)),
+         "Yes" if info.get("declared") else "No"]
+        for fam, info in sorted(families.items())
+    ]
+    parts.append(f"""
+    <h3>Correlation</h3>
+    <div class='hero'>
+      {html_kit.kpi("Undeclared capability candidates", undeclared, accent='#b45309')}
+      {html_kit.kpi("Orphaned declared tools", orphaned, accent='#6b7280')}
+    </div>
+    {html_kit.data_table(
+        ["Family", "Referenced names", "Declared"],
+        fam_rows,
+        empty="No correlated families.",
+        searchable=False,
+    )}
+    <p class='muted'>Name-family heuristic correlation from static references; not proof of runtime behaviour.</p>""")
+
+    return f"""
+    <h2>Dependency Inventory & Correlation</h2>
+    {'<h3>Referenced configuration / credentials</h3><p class="muted">Names and source locations only — values are never read or stored.</p>' if inventory else ''}
+    {''.join(parts)}"""
+
+
 def _kya_section(report):
     """Render the Know Your Agent section: agents, policy, registry status."""
     agents = report.get("kya_agents")
@@ -257,6 +313,8 @@ def write_html(report, path):
     {html_kit.data_table(["Capability", "Category", "Frameworks", "Confidence", "Evidence"], capability_rows, empty="No capabilities detected.")}
 
     {_escalation_section(report)}
+
+    {_dependency_section(report)}
 
     <h2>Governance Summary</h2>
     {html_kit.data_table(

--- a/safeai/report/terminal.py
+++ b/safeai/report/terminal.py
@@ -19,6 +19,17 @@ def print_summary(report):
             kind = component.get("type", "unknown")
             component_counts[kind] = component_counts.get(kind, 0) + 1
         print("Components:", ", ".join(f"{k}={v}" for k, v in sorted(component_counts.items())) or "none")
+    inventory = report.get("dependency_inventory")
+    if inventory is not None:
+        print("External config/credential names:", len(inventory))
+    correlation = report.get("dependency_correlation")
+    if correlation and correlation.get("counts"):
+        counts = correlation["counts"]
+        print(
+            "Dependency correlation:",
+            f"{counts.get('undeclared', 0)} undeclared-capability candidates /",
+            f"{counts.get('orphaned', 0)} orphaned declared tools",
+        )
     if report.get("diagnostics"):
         print("Diagnostics:", len(report["diagnostics"]))
     if report.get("capability_diff"):

--- a/safeai/rules/base_rules.yaml
+++ b/safeai/rules/base_rules.yaml
@@ -275,3 +275,20 @@
   description: Claude Code configuration file could not be parsed and cannot be reviewed or enforced
   severity: low
   owasp_llm: LLM09
+
+# --- CE 1.5: dependency-to-capability correlation ---
+
+- id: ENV_DEP_INVENTORY
+  description: Referenced external configuration/credential names (inventory; informational)
+  severity: info
+  owasp_llm: LLM02
+
+- id: DEP_UNDECLARED_CAPABILITY
+  description: Referenced credential/config has no matching declared capability
+  severity: medium
+  owasp_llm: LLM02
+
+- id: DEP_ORPHANED_TOOL
+  description: Declared capability lacks a matching credential/config reference
+  severity: low
+  owasp_llm: LLM06

--- a/tests/test_env_dependency.py
+++ b/tests/test_env_dependency.py
@@ -1,0 +1,159 @@
+"""Tests for the CE 1.5 env-dependency inventory and capability correlation."""
+
+import json
+import os
+
+from safeai.analysis.dependency_correlation import (
+    RULE_ORPHAN,
+    RULE_UNDECLARED,
+    correlate_dependencies,
+    family_of_capability,
+    family_of_config,
+)
+from safeai.analyzers.env_dependency.analyzer import EnvDependencyAnalyzer
+from safeai.cmd.cli import main
+
+_RULES = [{"id": "ENV_DEP_INVENTORY", "severity": "info", "owasp_llm": "LLM02"}]
+
+
+def _run(code, rules=_RULES, path="./app.py"):
+    analyzer = EnvDependencyAnalyzer()
+    return analyzer.run({path: code}, rules or [])
+
+
+def test_detects_getenv_reference():
+    findings = _run("import os\nk = os.getenv('DATABASE_URL')\n")
+    inv = findings[0]["dep_inventory"]
+    assert any(e["name"] == "DATABASE_URL" for e in inv)
+
+
+def test_detects_os_environ_and_process_env():
+    findings = _run(
+        "import os\nx = os.environ['AWS_SECRET']\n"
+        "// js\nconst t = process.env.OPENAI_API_KEY;\n"
+    )
+    inv = {e["name"] for e in findings[0]["dep_inventory"]}
+    assert "AWS_SECRET" in inv
+    assert "OPENAI_API_KEY" in inv
+
+
+def test_flags_secret_names_only_never_values():
+    # A value is present in the dotenv source line, but only the name may surface.
+    findings = _run("DATABASE_URL=postgres://u:password123@host/db\n",
+                    rules=[], path="./.env")
+    raw = json.dumps(findings[0]["dep_inventory"])
+    assert "password123" not in raw
+    assert "DATABASE_URL" in raw
+
+
+def test_flags_secret_backed_detectors():
+    findings = _run(
+        "import boto3\nx = boto3.client('secretsmanager').get_secret_value('prod/mysql')\n"
+    )
+    inv = findings[0]["dep_inventory"]
+    assert any(e["name"] == "prod/mysql" and e["secret"] for e in inv)
+
+
+def test_secret_by_name_keyword():
+    findings = _run("import os\np = os.getenv('AWS_SECRET_ACCESS_KEY')\n")
+    inv = findings[0]["dep_inventory"]
+    assert any(e["name"] == "AWS_SECRET_ACCESS_KEY" and e["secret"] for e in inv)
+
+
+def test_k8s_secret_ref():
+    findings = _run("apiVersion: v1\nkind: Pod\nspec:\n  secretKeyRef: {name: db-creds}\n")
+    inv = findings[0]["dep_inventory"]
+    assert any(e["name"] == "db-creds" and e["secret"] for e in inv)
+
+
+def test_family_of_config():
+    assert family_of_config("DATABASE_URL") == "database"
+    assert family_of_config("OPENAI_API_KEY") == "api"
+    assert family_of_config("AWS_SECRET_ACCESS_KEY") == "cloud"
+    assert family_of_config("DEBUG") is None
+
+
+def test_family_matching_is_word_segment_based():
+    # Short tokens must not match inside unrelated words (CE 1.5 review #2):
+    # "jdbc" contains "db" and "rabbit_mq" contains "rabbit" but neither is a
+    # segment-level match on the family axis.
+    assert family_of_config("JDBC_URL") == "api"  # via url, not database
+    assert family_of_config("MYJIRA_EMAIL") is None
+    assert family_of_config("RABBIT_QUEUE") == "messaging"
+    assert family_of_config("SLACK_TOKEN") == "messaging"
+    # Provider families take precedence over the generic api suffix tokens so a
+    # SLACK_TOKEN stays aligned with a declared slack capability.
+    assert family_of_config("DATABASE_SSL") == "database"
+
+
+def test_family_of_capability():
+    assert family_of_capability("databases") == "database"
+    assert family_of_capability("external_apis") == "api"
+    assert family_of_capability("s3") == "cloud"
+
+
+def test_correlate_undeclared_capability():
+    report = {
+        "findings": [{
+            "rule_id": "ENV_DEP_INVENTORY",
+            "dep_inventory": [
+                {"name": "DATABASE_URL", "secret": False,
+                 "sources": [{"file": "app.py", "line": 5}]},
+            ],
+        }],
+        "tool_surface": [],
+    }
+    findings, summary = correlate_dependencies(report)
+    assert any(f["rule_id"] == RULE_UNDECLARED for f in findings)
+    assert summary["counts"]["undeclared"] == 1
+
+
+def test_correlate_declared_capability_not_flagged():
+    report = {
+        "findings": [{
+            "rule_id": "ENV_DEP_INVENTORY",
+            "dep_inventory": [
+                {"name": "OPENAI_API_KEY", "secret": True,
+                 "sources": [{"file": "app.py", "line": 6}]},
+            ],
+        }],
+        "tool_surface": [
+            {"tool_key": "t:llm", "capabilities": [{"name": "external_apis"}]},
+        ],
+    }
+    findings, _ = correlate_dependencies(report)
+    assert not any(f["rule_id"] == RULE_UNDECLARED for f in findings)
+
+
+def test_correlate_orphaned_tool():
+    report = {
+        "findings": [{
+            "rule_id": "ENV_DEP_INVENTORY",
+            "dep_inventory": [],
+        }],
+        "tool_surface": [
+            {"tool_key": "t:s3", "capabilities": [{"name": "s3"}]},
+        ],
+    }
+    findings, _ = correlate_dependencies(report)
+    assert any(f["rule_id"] == RULE_ORPHAN for f in findings)
+
+
+def test_cli_scan_includes_inventory():
+    # End-to-end: a scan surfaces the inventory + correlation in the manifest.
+    root = os.path.join(os.path.dirname(__file__), "fixtures", "ce15_project")
+    if not os.path.isdir(root):
+        import tempfile
+
+        temp = tempfile.mkdtemp()
+        with open(os.path.join(temp, "agent.py"), "w", encoding="utf-8") as fh:
+            fh.write("import os\nk = os.getenv('DATABASE_URL')\n")
+        root = temp
+    manifest_path = os.path.join(root, "safeai-manifest.json")
+    rc = main(["scan", root, "--manifest", manifest_path, "--no-registry",
+               "--sarif", os.path.join(root, "out.sarif")])
+    assert rc in (0, 1)
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    assert "dependency_inventory" in manifest
+    assert isinstance(manifest["summary"]["dependency_count"], int)

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -135,7 +135,12 @@ def test_registry_export_excludes_suppressed_by_default(kya_project, tmp_path):
     from safeai.kya.registry import connect, get_scan_findings, latest_scan_id
     conn = connect(reg)
     findings = get_scan_findings(conn, latest_scan_id(conn))
-    fp = findings[0]["fingerprint"]
+    carrying = {"ENV_DEP_INVENTORY", "MCP_ASSETS_DISCOVERED"}
+    fp = next(
+        f["fingerprint"]
+        for f in findings
+        if f.get("rule_id") not in carrying
+    )
     conn.close()
 
     safeai_dir = os.path.join(kya_project["root"], ".safeai")

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -117,6 +117,30 @@ suppressions:
     assert out_scope["status"] == "new"
 
 
+def test_carrying_inventory_finding_not_suppressible(tmp_path):
+    # The ENV_DEP_INVENTORY finding carries the dependency inventory payload;
+    # a suppression must never blank it (CE 1.5 review #3).
+    path = _write(tmp_path, """
+suppressions:
+  - rule_id: ENV_DEP_INVENTORY
+    reason: "noise"
+    owner: "team"
+    created: "2026-01-01"
+""")
+    entries, _ = load_suppressions(path)
+    carrying = {
+        "rule_id": "ENV_DEP_INVENTORY",
+        "file": "src/app.py",
+        "severity": "info",
+        "dep_inventory": [{"name": "DATABASE_URL"}],
+    }
+    dep_finding = _finding(rule="DEP_ORPHANED_TOOL")
+    apply_suppressions([carrying, dep_finding], entries)
+    assert carrying.get("status") != "suppressed"
+    assert "dep_inventory" in carrying
+    assert dep_finding["status"] == "new"
+
+
 def test_suppressed_findings_stay_in_json_output(kya_project, tmp_path):
     # First scan to learn a fingerprint.
     first_json = os.path.join(str(tmp_path), "first.json")
@@ -125,7 +149,12 @@ def test_suppressed_findings_stay_in_json_output(kya_project, tmp_path):
     import json
     with open(first_json) as fh:
         report = json.load(fh)
-    fp = report["findings"][0]["fingerprint"]
+    carrying = {"ENV_DEP_INVENTORY", "MCP_ASSETS_DISCOVERED"}
+    fp = next(
+        f["fingerprint"]
+        for f in report["findings"]
+        if f.get("rule_id") not in carrying
+    )
 
     safeai_dir = os.path.join(kya_project["root"], ".safeai")
     os.makedirs(safeai_dir, exist_ok=True)


### PR DESCRIPTION
Implements the 4 targeted hardening items from the CE 1.5 architecture review:

**Issue 1/4 (orchestrator):** Single count/score/relativize pass — correlation findings appended, relativized, and sorted before _count_severities()/score_report()/_relativize_report() run exactly once.

**Issue 2 (family model):** Word-segment matching (_parse_words) replaces raw substring; provider families (cloud/database/messaging) take precedence over generic pi fallback. Eliminates false positives like jdbc→database and abbit_mq→messaging; aligns SLACK_TOKEN/JIRA_TOKEN with declared capabilities.

**Issue 3 (suppressions):** pply_suppressions now exempts payload-carrying findings (ENV_DEP_INVENTORY, MCP_ASSETS_DISCOVERED) so a broad ule_id/path suppression cannot blank the dependency-inventory section.

**Verification:** 349 tests pass, uff clean.

**Docs:** CHANGELOG.md + ROADMAP.md updated with findings-count note and family-model summary.

Closes #27.