### PR TITLE
test: validate Claude Code project compatibility

### DIFF
--- a/tests/fixtures/claude_code/compatibility/.claude/settings.json
+++ b/tests/fixtures/claude_code/compatibility/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": ["Read(docs/**)", "mcp__docs__search"],
+    "deny": ["Bash(*)"]
+  },
+  "subagents": {
+    "researcher": {
+      "description": "Read-only documentation researcher",
+      "tools": ["Read", "Grep", "mcp__docs__search"]
+    }
+  }
+}

--- a/tests/fixtures/claude_code/compatibility/.mcp.json
+++ b/tests/fixtures/claude_code/compatibility/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "docs": {
+      "command": "node",
+      "args": ["fixtures/docs-server.js"]
+    }
+  }
+}

--- a/tests/fixtures/claude_code/compatibility/CLAUDE.md
+++ b/tests/fixtures/claude_code/compatibility/CLAUDE.md
@@ -1,0 +1,5 @@
+# Synthetic Claude Code project
+
+Use claude-sonnet-4-20250514 with the `mcp__docs__search` tool to look up project documentation. The project may use a read-only research subagent for documentation tasks.
+
+Never include credentials, private instructions, or production endpoints in this fixture.

--- a/tests/test_claude_code_deep.py
+++ b/tests/test_claude_code_deep.py
@@ -55,6 +55,17 @@ def test_minimal_project_still_extracts_named_tools():
     assert "tool:grep" in surface_keys(report)
 
 
+def test_compatibility_fixture_detects_claude_code_project_surfaces():
+    """Validate the common Claude Code project files in one deterministic fixture."""
+    report = scan("compatibility")
+
+    assert "claude_code" in report["detected_frameworks"]
+    assert "mcp_server:docs" in surface_keys(report)
+    assert "tool:read" in surface_keys(report)
+    assert any(model["file"] == "CLAUDE.md" for model in report["agent_models"])
+    assert any(f["rule_id"] == "MCP_ASSETS_DISCOVERED" for f in report["findings"])
+
+
 # --- permissive ----------------------------------------------------------
 
 


### PR DESCRIPTION
## What
Add a deterministic, credential-free Claude Code compatibility fixture and an end-to-end test covering `CLAUDE.md`, scoped permissions, MCP discovery, tool-surface extraction, and model metadata.

## Why
This validates common Claude Code project structures and documents the analyzer behavior without using real prompts, secrets, proprietary instructions, or live endpoints.

## Test plan
- `python -m pytest -q tests/test_claude_code_deep.py`
- Result: 46 passed
- `git diff --check` passed

Fixes #57