### PR TITLE
test: validate n8n workflow compatibility

### DIFF
--- a/safeai/frameworks/n8n/parser.py
+++ b/safeai/frameworks/n8n/parser.py
@@ -115,12 +115,20 @@ class N8nParser:
                 if isinstance(targets, dict):
                     for target_type, target_list in targets.items():
                         if isinstance(target_list, list):
-                            for target in target_list:
-                                result["relationships"].append({
-                                    "source": source,
-                                    "target": target.get("node", ""),
-                                    "type": target_type,
-                                })
+                            for target_group in target_list:
+                                targets = (
+                                    target_group
+                                    if isinstance(target_group, list)
+                                    else [target_group]
+                                )
+                                for target in targets:
+                                    if not isinstance(target, dict):
+                                        continue
+                                    result["relationships"].append({
+                                        "source": source,
+                                        "target": target.get("node", ""),
+                                        "type": target_type,
+                                    })
 
     def _parse_python(self, content, result, caps):
         for m in re.finditer(r"n8n", content, re.IGNORECASE):

--- a/tests/fixtures/n8n/representative/workflow.json
+++ b/tests/fixtures/n8n/representative/workflow.json
@@ -1,0 +1,36 @@
+{
+  "name": "Support triage",
+  "nodes": [
+    {
+      "name": "Incoming webhook",
+      "type": "n8n-nodes-base.webhook",
+      "parameters": { "path": "support-triage" }
+    },
+    {
+      "name": "Classify request",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "parameters": { "model": "synthetic-model" }
+    },
+    {
+      "name": "Load ticket context",
+      "type": "n8n-nodes-base.postgres",
+      "parameters": { "operation": "select", "credential": "postgres-placeholder" }
+    },
+    {
+      "name": "Run local check",
+      "type": "n8n-nodes-base.executeCommand",
+      "parameters": { "command": "printf synthetic-check" }
+    }
+  ],
+  "connections": {
+    "Incoming webhook": {
+      "main": [[{ "node": "Classify request", "type": "main", "index": 0 }]]
+    },
+    "Classify request": {
+      "main": [[{ "node": "Load ticket context", "type": "main", "index": 0 }]]
+    },
+    "Load ticket context": {
+      "main": [[{ "node": "Run local check", "type": "main", "index": 0 }]]
+    }
+  }
+}

--- a/tests/test_n8n_workflow.py
+++ b/tests/test_n8n_workflow.py
@@ -42,7 +42,8 @@ def test_representative_n8n_workflow_is_detected_and_parsed():
 
 def test_representative_n8n_fixture_has_no_credential_values_or_private_endpoints():
     workflow_path = os.path.join(FIXTURE, "workflow.json")
-    workflow_text = open(workflow_path, encoding="utf-8").read()
+    with open(workflow_path, encoding="utf-8") as f:
+        workflow_text = f.read()
     workflow = json.loads(workflow_text)
 
     assert "credential" in workflow_text

--- a/tests/test_n8n_workflow.py
+++ b/tests/test_n8n_workflow.py
@@ -1,0 +1,56 @@
+import json
+import os
+
+from safeai.engine.scan import run_scan
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "n8n", "representative"
+)
+
+
+def test_representative_n8n_workflow_is_detected_and_parsed():
+    report = run_scan(FIXTURE)
+
+    assert "n8n" in report["detected_frameworks"]
+    model = next(
+        model
+        for model in report["unified_models"]
+        if "n8n" in model.get("frameworks", [])
+    )
+    artifacts = model["artifacts"]
+    assert [workflow["name"] for workflow in artifacts["workflows"]] == [
+        "Support triage"
+    ]
+    assert {tool["name"] for tool in artifacts["tools"]} == {
+        "Incoming webhook",
+        "Classify request",
+        "Load ticket context",
+        "Run local check",
+    }
+    assert "synthetic-model" in {
+        model_entry["name"] for model_entry in artifacts["models"]
+    }
+    assert len(model["relationships"]) == 3
+
+    capability_names = {
+        capability["name"] for capability in model["capabilities"]
+    }
+    assert {"external_apis", "databases", "shell", "external_model_api"}.issubset(
+        capability_names
+    )
+
+
+def test_representative_n8n_fixture_has_no_credential_values_or_private_endpoints():
+    workflow_path = os.path.join(FIXTURE, "workflow.json")
+    workflow_text = open(workflow_path, encoding="utf-8").read()
+    workflow = json.loads(workflow_text)
+
+    assert "credential" in workflow_text
+    assert "postgres-placeholder" in workflow_text
+    assert "password" not in workflow_text.lower()
+    assert "token" not in workflow_text.lower()
+    assert all(
+        node.get("parameters", {}).get("url", "").startswith("https://example.invalid")
+        for node in workflow["nodes"]
+        if "url" in node.get("parameters", {})
+    )


### PR DESCRIPTION
## What
Add a deterministic representative n8n workflow fixture and integration coverage for framework detection, workflow and node extraction, relationships, external APIs, databases, shell execution, and AI-model capabilities.

Also fix the n8n parser to handle the nested connection-array shape emitted by n8n exports.

## Safety
The fixture uses a synthetic model and a placeholder credential reference only. It contains no tokens, passwords, private data, or live endpoints.

## Test plan
- `python -m pytest tests/test_n8n_workflow.py -q`
- `python -m pytest tests/test_claude_code_deep.py -q`
- `python -m pytest tests -q`
- Result: 460 passed, 1 skipped

Fixes #56