### PR TITLE
test: validate LlamaIndex framework detection

### DIFF
--- a/tests/fixtures/llamaindex/representative/agent.py
+++ b/tests/fixtures/llamaindex/representative/agent.py
@@ -1,0 +1,17 @@
+from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
+from llama_index.core.agent import ReActAgent
+from llama_index.core.tools import FunctionTool
+from llama_index.llms.openai import OpenAI
+from llama_index.core.utilities.sql_wrapper import SQLDatabase
+
+
+def lookup_ticket(ticket_id: str) -> str:
+    return f"synthetic ticket {ticket_id}"
+
+
+documents = SimpleDirectoryReader("./synthetic-docs").load_data()
+index = VectorStoreIndex.from_documents(documents)
+ticket_tool = FunctionTool(name="lookup_ticket")
+model = OpenAI(model="synthetic-model")
+database = SQLDatabase("synthetic-connection")
+agent = ReActAgent(name="Support agent", tools=[ticket_tool], llm=model)

--- a/tests/fixtures/llamaindex/representative/agent.py
+++ b/tests/fixtures/llamaindex/representative/agent.py
@@ -1,8 +1,8 @@
 from llama_index.core import SimpleDirectoryReader, VectorStoreIndex
 from llama_index.core.agent import ReActAgent
 from llama_index.core.tools import FunctionTool
-from llama_index.llms.openai import OpenAI
 from llama_index.core.utilities.sql_wrapper import SQLDatabase
+from llama_index.llms.openai import OpenAI
 
 
 def lookup_ticket(ticket_id: str) -> str:

--- a/tests/test_llamaindex_framework.py
+++ b/tests/test_llamaindex_framework.py
@@ -1,0 +1,30 @@
+import os
+
+from safeai.engine.scan import run_scan
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "llamaindex", "representative"
+)
+
+
+def test_representative_llamaindex_project_is_detected_and_parsed():
+    report = run_scan(FIXTURE)
+
+    assert "llamaindex" in report["detected_frameworks"]
+    model = next(
+        model
+        for model in report["unified_models"]
+        if "llamaindex" in model.get("frameworks", [])
+    )
+    artifacts = model["artifacts"]
+
+    assert "Support agent" in {agent["name"] for agent in artifacts["agents"]}
+    assert "lookup_ticket" in {tool["name"] for tool in artifacts["tools"]}
+    assert "synthetic-model" in {
+        model_entry["name"] for model_entry in artifacts["models"]
+    }
+
+    capability_names = {
+        capability["name"] for capability in model["capabilities"]
+    }
+    assert {"rag", "external_model_api", "databases"}.issubset(capability_names)


### PR DESCRIPTION
## What
Add a representative dependency-free LlamaIndex fixture and integration coverage for framework detection, RAG indexing, agent and tool extraction, model references, and database capabilities.

The fixture uses synthetic names and contains no credentials, tokens, private data, or live service calls.

## Test plan
- `python -m pytest tests/test_llamaindex_framework.py -q`
- `python -m pytest tests -q`
- Result: 459 passed, 1 skipped

Fixes #55