### PR TITLE
test: validate CrewAI framework detection

### DIFF
--- a/tests/fixtures/crewai/representative/crew.py
+++ b/tests/fixtures/crewai/representative/crew.py
@@ -1,0 +1,21 @@
+from crewai import Agent, Crew, LLM, Task
+from crewai.memory import Memory
+from crewai.tools import Tool
+
+
+lookup_ticket = Tool(name="lookup_ticket")
+
+model = LLM(model="synthetic-model")
+crew_memory = Memory()
+triage_agent = Agent(
+    role="Support triage",
+    goal="Classify synthetic support requests",
+    tools=[lookup_ticket],
+    llm=model,
+)
+triage_task = Task(
+    description="Classify the incoming synthetic request",
+    expected_output="A category",
+    agent=triage_agent,
+)
+crew = Crew(agents=[triage_agent], tasks=[triage_task], memory=crew_memory)

--- a/tests/fixtures/crewai/representative/crew.py
+++ b/tests/fixtures/crewai/representative/crew.py
@@ -1,4 +1,4 @@
-from crewai import Agent, Crew, LLM, Task
+from crewai import LLM, Agent, Crew, Task
 from crewai.memory import Memory
 from crewai.tools import Tool
 

--- a/tests/fixtures/crewai/representative/crew.py
+++ b/tests/fixtures/crewai/representative/crew.py
@@ -2,7 +2,6 @@ from crewai import LLM, Agent, Crew, Task
 from crewai.memory import Memory
 from crewai.tools import Tool
 
-
 lookup_ticket = Tool(name="lookup_ticket")
 
 model = LLM(model="synthetic-model")

--- a/tests/test_crewai_framework.py
+++ b/tests/test_crewai_framework.py
@@ -1,0 +1,30 @@
+import os
+
+from safeai.engine.scan import run_scan
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "crewai", "representative"
+)
+
+
+def test_representative_crewai_project_is_detected_and_parsed():
+    report = run_scan(FIXTURE)
+
+    assert "crewai" in report["detected_frameworks"]
+    model = next(
+        model
+        for model in report["unified_models"]
+        if "crewai" in model.get("frameworks", [])
+    )
+    artifacts = model["artifacts"]
+
+    assert any("Agent" in agent["name"] for agent in artifacts["agents"])
+    assert any("Task" in task["name"] for task in artifacts["workflows"])
+    assert any(tool["name"] == "Tool" for tool in artifacts["tools"])
+    assert any("Memory" in memory["name"] for memory in artifacts["memory"])
+    assert any("LLM" in model_entry["name"] for model_entry in artifacts["models"])
+
+    capability_names = {
+        capability["name"] for capability in model["capabilities"]
+    }
+    assert {"memory", "external_model_api"}.issubset(capability_names)


### PR DESCRIPTION
## What
Add a representative dependency-free CrewAI fixture and integration coverage for agents, tasks, tools, memory, model references, and framework capabilities.

The fixture uses synthetic names only and contains no credentials, tokens, private data, or live service calls.

## Test plan
- `python -m pytest tests/test_crewai_framework.py -q`
- `python -m pytest tests -q`
- Result: 459 passed, 1 skipped

Fixes #54