### PR TITLE
test: validate LangGraph framework detection

### DIFF
--- a/tests/fixtures/langgraph/representative/graph.py
+++ b/tests/fixtures/langgraph/representative/graph.py
@@ -1,0 +1,23 @@
+from langchain_openai import ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, StateGraph
+from langgraph.prebuilt import ToolNode
+
+
+def classify(state):
+    return {"label": "synthetic"}
+
+
+def answer(state):
+    return {"answer": "synthetic response"}
+
+
+graph = StateGraph(dict)
+graph.add_node("classify", classify)
+graph.add_node("answer", answer)
+graph.add_edge("classify", "answer")
+graph.add_edge("answer", END)
+model = ChatOpenAI(model="synthetic-model")
+checkpoint = MemorySaver()
+tool_node = ToolNode([])
+compiled = graph.compile(checkpointer=checkpoint)

--- a/tests/test_langgraph_framework.py
+++ b/tests/test_langgraph_framework.py
@@ -1,0 +1,32 @@
+import os
+
+from safeai.engine.scan import run_scan
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "langgraph", "representative"
+)
+
+
+def test_representative_langgraph_project_is_detected_and_parsed():
+    report = run_scan(FIXTURE)
+
+    assert "langgraph" in report["detected_frameworks"]
+    model = next(
+        model
+        for model in report["unified_models"]
+        if "langgraph" in model.get("frameworks", [])
+    )
+    artifacts = model["artifacts"]
+
+    assert any("graph.add_edge" in workflow["name"] for workflow in artifacts["workflows"])
+    assert any("ToolNode" in tool["name"] for tool in artifacts["tools"])
+    assert any(
+        memory["name"] == "MemorySaver"
+        and "langgraph" in memory["frameworks"]
+        for memory in artifacts["memory"]
+    )
+
+    capability_names = {
+        capability["name"] for capability in model["capabilities"]
+    }
+    assert "memory" in capability_names


### PR DESCRIPTION
## What
Add a representative dependency-free LangGraph fixture and integration coverage for graph edges, tool nodes, memory checkpointing, and framework detection.

The fixture uses synthetic names only and contains no credentials, tokens, private data, or live service calls.

## Test plan
- `python -m pytest tests/test_langgraph_framework.py -q`
- `python -m pytest tests -q`
- Result: 459 passed, 1 skipped

Fixes #53