### PR TITLE
feat: add registry components command

### DIFF
--- a/safeai/cmd/cli.py
+++ b/safeai/cmd/cli.py
@@ -117,6 +117,18 @@ def _build_parser():
     _common(reg_hist)
     reg_hist.add_argument("agent_id")
 
+    reg_components = reg_sub.add_parser("components", help="List known registry components")
+    reg_components.add_argument("--registry", help="Registry database path")
+    reg_components.add_argument("--project-dir", dest="project_dir",
+                                help="Inspect the per-project registry at DIR/.safeai/registry.db")
+    reg_components.add_argument("--format", choices=["table", "json"], default="table")
+    reg_components.add_argument("--json", dest="json_output", action="store_true",
+                                help="Emit JSON output")
+    reg_components.add_argument("--type", dest="component_type",
+                                help="Filter by component type (for example: mcp, skill, prompt)")
+    reg_components.add_argument("--agents", action="store_true",
+                                help="Show agents that reference each component")
+
     reg_diff = reg_sub.add_parser("diff", help="Compare two snapshots of an agent")
     _common(reg_diff)
     reg_diff.add_argument("agent_id")
@@ -260,7 +272,10 @@ def main(argv=None):
 
     if args.command == "registry":
         if not getattr(args, "registry_command", None):
-            parser.error("registry requires a subcommand: list|show|history|diff|export|metadata")
+            parser.error(
+                "registry requires a subcommand: "
+                "list|show|history|components|diff|export|metadata",
+            )
         from safeai.cmd.registry_cli import run_registry_command
         return run_registry_command(args)
 

--- a/safeai/cmd/registry_cli.py
+++ b/safeai/cmd/registry_cli.py
@@ -18,9 +18,11 @@ from safeai.kya.registry import (
     default_registry_path,
     get_agent,
     get_agent_scan_findings,
+    get_component_agents,
     get_snapshot,
     get_tool_snapshots,
     list_agents,
+    list_components,
     registry_exists,
     resolve_scan_ref,
     shared_registry_path,
@@ -180,6 +182,68 @@ def cmd_history(args):
     ]
     print(f"History for agent {args.agent_id} ({len(rows)} scans)")
     _table(rows, ["SCAN", "COMPLETED", "COMMIT", "POLICY", "RISK", "CAPS", "SEVERITIES"])
+    return 0
+
+
+def _latest_components(components):
+    """Return the latest snapshot for each component identity."""
+    latest = {}
+    for component in components:
+        key = (component.get("component_type"), component.get("file_path"))
+        previous = latest.get(key)
+        if previous is None or component.get("id", 0) > previous.get("id", 0):
+            latest[key] = component
+    return sorted(
+        latest.values(),
+        key=lambda item: (
+            item.get("component_type") or "",
+            item.get("name") or "",
+            item.get("file_path") or "",
+        ),
+    )
+
+
+def cmd_components(args):
+    """List component snapshots and their consuming agents."""
+    conn = _open_registry(args.registry_path)
+    try:
+        components = _latest_components(
+            list_components(conn, component_type=getattr(args, "component_type", None)),
+        )
+        if getattr(args, "agents", False):
+            for component in components:
+                component["agents"] = get_component_agents(
+                    conn,
+                    component["component_type"],
+                    component["file_path"],
+                )
+    finally:
+        conn.close()
+
+    if getattr(args, "json_output", False) or args.format == "json":
+        _print_json({"components": components, "disclaimer": STATIC_ANALYSIS_DISCLAIMER})
+        return 0
+
+    print(f"Known components ({len(components)}) - static evidence only")
+    grouped = {}
+    for component in components:
+        grouped.setdefault(component.get("component_type") or "unknown", []).append(component)
+    for component_type, items in grouped.items():
+        print(f"\n[{component_type}]")
+        rows = []
+        for component in items:
+            agents = component.get("agents") or []
+            rows.append((
+                component.get("name") or "-",
+                component.get("file_path") or "-",
+                component.get("first_seen_scan") or "-",
+                component.get("last_seen_scan") or "-",
+                ", ".join(agent["agent_id"] for agent in agents) or "-",
+            ))
+        headers = ["NAME", "PATH", "FIRST SEEN", "LAST SEEN"]
+        if getattr(args, "agents", False):
+            headers.append("AGENTS")
+        _table([row if getattr(args, "agents", False) else row[:-1] for row in rows], headers)
     return 0
 
 
@@ -401,6 +465,7 @@ def run_registry_command(args):
             "diff": cmd_diff,
             "export": cmd_export,
             "metadata": cmd_metadata,
+            "components": cmd_components,
         }[args.registry_command]
         return handler(args)
     except RegistryError as exc:

--- a/tests/test_registry_components.py
+++ b/tests/test_registry_components.py
@@ -1,0 +1,124 @@
+"""Tests for the ``safeai registry components`` command."""
+
+import json
+
+from safeai.cmd.cli import main
+from safeai.kya.registry import init_registry
+
+
+def _component_registry(tmp_path):
+    registry = str(tmp_path / "registry.db")
+    conn, _ = init_registry(registry)
+    conn.execute(
+        "INSERT INTO projects(project_id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        ("project-1", "demo", "2026-01-01", "2026-01-02"),
+    )
+    for scan_id, completed_at in (("scan-1", "2026-01-01"), ("scan-2", "2026-01-02")):
+        conn.execute(
+            "INSERT INTO scans(scan_id, project_id, completed_at, manifest_json, manifest_hash) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (scan_id, "project-1", completed_at, "{}", scan_id),
+        )
+    conn.execute(
+        "INSERT INTO agents(agent_id, project_id, name, framework, first_seen, last_seen) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("agent-1", "project-1", "Demo agent", "langgraph", "2026-01-01", "2026-01-02"),
+    )
+    conn.execute(
+        "INSERT INTO agent_snapshots(agent_id, scan_id, snapshot_json) VALUES (?, ?, ?)",
+        ("agent-1", "scan-2", "{}"),
+    )
+    components = [
+        ("scan-1", "skill", "summarize", "skills/summarize.md", "scan-1", "scan-1"),
+        ("scan-2", "skill", "summarize", "skills/summarize.md", "scan-1", "scan-2"),
+        ("scan-2", "prompt", "review", "prompts/review.md", "scan-2", "scan-2"),
+    ]
+    conn.executemany(
+        "INSERT INTO component_snapshots("
+        "scan_id, component_type, name, file_path, first_seen_scan, last_seen_scan"
+        ") VALUES (?, ?, ?, ?, ?, ?)",
+        components,
+    )
+    conn.commit()
+    conn.close()
+    return registry
+
+
+def test_registry_components_groups_latest_snapshots(tmp_path, capsys):
+    registry = _component_registry(tmp_path)
+
+    assert main(["registry", "components", "--registry", registry]) == 0
+
+    output = capsys.readouterr().out
+    assert "Known components (2)" in output
+    assert "[prompt]" in output and "[skill]" in output
+    assert "scan-1" in output and "scan-2" in output
+
+
+def test_registry_components_filters_by_type(tmp_path, capsys):
+    registry = _component_registry(tmp_path)
+
+    assert (
+        main(
+            [
+                "registry",
+                "components",
+                "--registry",
+                registry,
+                "--type",
+                "prompt",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "review" in output
+    assert "summarize" not in output
+
+
+def test_registry_components_shows_consuming_agents(tmp_path, capsys):
+    registry = _component_registry(tmp_path)
+
+    assert (
+        main(
+            [
+                "registry",
+                "components",
+                "--registry",
+                registry,
+                "--agents",
+            ]
+        )
+        == 0
+    )
+
+    output = capsys.readouterr().out
+    assert "AGENTS" in output
+    assert "agent-1" in output
+
+
+def test_registry_components_json_output(tmp_path, capsys):
+    registry = _component_registry(tmp_path)
+
+    assert (
+        main(
+            [
+                "registry",
+                "components",
+                "--registry",
+                registry,
+                "--agents",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["components"]) == 2
+    summarize = next(
+        item for item in payload["components"] if item["name"] == "summarize"
+    )
+    assert summarize["last_seen_scan"] == "scan-2"
+    assert summarize["agents"][0]["agent_id"] == "agent-1"


### PR DESCRIPTION
## Summary
- expose registry components through a new offline CLI subcommand
- support grouped table output, type filtering, consuming-agent attribution, and JSON output
- collapse historical snapshots to the latest record while preserving first/last seen metadata
- add focused coverage for all four command modes

## Tests
- PYTHONUTF8=1 python -m pytest -q (481 passed, 1 skipped)
- python -m pytest tests/test_registry_components.py tests/test_registry_cli.py -q (19 passed)
- ruff check safeai/cmd/cli.py safeai/cmd/registry_cli.py tests/test_registry_components.py

Closes #81