### PR TITLE
feat: add safeai init command

### DIFF
--- a/safeai/cmd/cli.py
+++ b/safeai/cmd/cli.py
@@ -9,6 +9,7 @@ Usage::
                             [--pr-comment <path>] [--pr-comment-stdout]
                             [--fail-on <level>] [--fail-on-new]
                             [--fail-on-escalation <level>]
+    safeai init [--profile <name>] [--force]
     safeai registry list|show|history|diff|export ...
 
 KYA (Know Your Agent) behavior:
@@ -27,9 +28,17 @@ KYA (Know Your Agent) behavior:
 """
 
 import argparse
+import os
+import re
+import subprocess
 import sys
 
+import yaml
+
 from safeai.cmd.postprocess import ScanPostProcessor
+from safeai.kya.policy import PolicyError, load_profile
+
+_POLICY_PROFILES = ("developer", "strict-ci", "mcp", "rag", "production-agent")
 
 
 def _build_parser():
@@ -93,6 +102,12 @@ def _build_parser():
     scan.add_argument("--mcp-ide-scopes", action="store_true",
                       help="Discover MCP configs in IDE scopes (.cursor/, .windsurf/, "
                            ".vscode/) in addition to the scanned repo")
+
+    init = sub.add_parser("init", help="Initialize SafeAI configuration in the current directory")
+    init.add_argument("--force", action="store_true",
+                      help="Overwrite existing SafeAI configuration files")
+    init.add_argument("--profile", choices=_POLICY_PROFILES, default="developer",
+                      help="Built-in policy profile to use (default: developer)")
 
     registry = sub.add_parser("registry", help="Inspect the local KYA registry")
     reg_sub = registry.add_subparsers(dest="registry_command")
@@ -159,6 +174,77 @@ def _run_scan_command(args, parser):
     outputs, exit code); this keeps the CLI a thin parsing shell.
     """
     return ScanPostProcessor(args, parser).run()
+
+
+def _agent_name(root):
+    """Derive a readable agent name from the git remote or directory."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            cwd=root,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+        remote = result.stdout.strip().rstrip("/")
+        if remote:
+            name = re.split(r"[/:]", remote)[-1].removesuffix(".git")
+            if name:
+                return name
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return os.path.basename(os.path.abspath(root)) or "agent"
+
+
+def _run_init(args, root=None):
+    """Create a starter ``.safeai`` configuration without losing user files."""
+    root = os.path.abspath(root or os.getcwd())
+    config_dir = os.path.join(root, ".safeai")
+    try:
+        profile = load_profile(args.profile)
+        if profile is None:
+            raise PolicyError(f"Unknown policy profile: {args.profile}")
+
+        files = {
+            "config.yml": yaml.safe_dump(
+                {
+                    "agent_name": _agent_name(root),
+                    "environment": "development",
+                    "lifecycle": "active",
+                },
+                sort_keys=False,
+            ),
+            "policy.yml": yaml.safe_dump(profile, sort_keys=False),
+            "suppressions.yml": (
+                "# Add reviewed findings here using their stable fingerprints.\n"
+                "# Include a reason, owner, and creation date for each suppression.\n"
+                "suppressions: []\n"
+            ),
+        }
+
+        os.makedirs(config_dir, exist_ok=True)
+        written = []
+        skipped = []
+        for filename, content in files.items():
+            path = os.path.join(config_dir, filename)
+            if os.path.exists(path) and not args.force:
+                skipped.append(filename)
+                continue
+            with open(path, "w", encoding="utf-8", newline="\n") as fh:
+                fh.write(content)
+            written.append(filename)
+    except (OSError, PolicyError, yaml.YAMLError) as exc:
+        print(f"Unable to initialize SafeAI: {exc}", file=sys.stderr)
+        return 2
+
+    for filename in written:
+        print(f"Created .safeai/{filename}")
+    for filename in skipped:
+        print(f"Skipped existing .safeai/{filename} (use --force to overwrite)")
+    print("SafeAI configuration is ready.")
+    print("Next: safeai scan .")
+    return 0
 
 
 def _configure_stdout():
@@ -257,6 +343,9 @@ def main(argv=None):
 
     if args.command == "scan":
         return _run_scan_command(args, parser)
+
+    if args.command == "init":
+        return _run_init(args)
 
     if args.command == "registry":
         if not getattr(args, "registry_command", None):

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,56 @@
+import pytest
+import yaml
+
+from safeai.cmd.cli import main
+
+
+def test_init_creates_default_configuration(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["init"]) == 0
+
+    config_dir = tmp_path / ".safeai"
+    config = yaml.safe_load((config_dir / "config.yml").read_text(encoding="utf-8"))
+    policy = yaml.safe_load((config_dir / "policy.yml").read_text(encoding="utf-8"))
+    suppressions = yaml.safe_load((config_dir / "suppressions.yml").read_text(encoding="utf-8"))
+    assert config == {
+        "agent_name": tmp_path.name,
+        "environment": "development",
+        "lifecycle": "active",
+    }
+    assert policy["description"].startswith("Balanced defaults")
+    assert suppressions == {"suppressions": []}
+    assert "safeai scan ." in capsys.readouterr().out
+
+
+def test_init_is_idempotent_without_force(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    assert main(["init"]) == 0
+    config_path = tmp_path / ".safeai" / "config.yml"
+    config_path.write_text("custom: true\n", encoding="utf-8")
+
+    assert main(["init"]) == 0
+
+    assert config_path.read_text(encoding="utf-8") == "custom: true\n"
+    assert "Skipped existing .safeai/config.yml" in capsys.readouterr().out
+
+
+def test_init_force_overwrites_with_selected_profile(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    assert main(["init"]) == 0
+    policy_path = tmp_path / ".safeai" / "policy.yml"
+    policy_path.write_text("custom: true\n", encoding="utf-8")
+    capsys.readouterr()
+
+    assert main(["init", "--force", "--profile", "strict-ci"]) == 0
+
+    policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    assert policy["description"].startswith("Strict CI gating")
+    assert "Skipped existing" not in capsys.readouterr().out
+
+
+def test_init_rejects_unknown_profile(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        main(["init", "--profile", "unknown"])


### PR DESCRIPTION
## Summary
- add safeai init with developer defaults and selectable built-in policy profiles
- preserve existing configuration unless --force is supplied
- derive the agent name from the git remote with a directory fallback
- add tests for creation, idempotency, force overwrite, and invalid profiles

## Validation
- python -m ruff check safeai/cmd/cli.py tests/test_cli_init.py
- python -m pytest tests/test_cli_init.py tests/test_registry_cli.py -q (19 passed)
- python -m pytest -q (481 passed, 1 skipped)

Closes #80