### PR TITLE
docs: add minimal GitHub Actions scanning example

### DIFF
--- a/.github/workflows/safeai-example.yml
+++ b/.github/workflows/safeai-example.yml
@@ -1,0 +1,47 @@
+name: SafeAI example scan
+
+on:
+  push:
+    paths:
+      - "examples/github-actions/**"
+      - ".github/workflows/safeai-example.yml"
+  pull_request:
+    paths:
+      - "examples/github-actions/**"
+      - ".github/workflows/safeai-example.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan synthetic agent
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run SafeAI
+        id: safeai
+        continue-on-error: true
+        uses: ikaruscareer/SafeAI@689b976b3f2380c77b151481ad1431c4696c90c8 # upstream main
+        with:
+          path: examples/github-actions
+          version: "1.8.0"
+          fail-on: critical
+          sarif: safeai-results.sarif
+          no-registry: "true"
+
+      - name: Upload SafeAI report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: safeai-example-report
+          path: safeai-results.sarif
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Propagate SafeAI result
+        if: always()
+        run: test "${{ steps.safeai.outcome }}" = success

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ examples/
     autogen/                # AutoGen-specific examples
     google-adk/             # Google ADK-specific examples
     n8n/                    # n8n workflow examples
+    github-actions/         # Synthetic fixture for the SafeAI Actions example
 ```
 
 ---
@@ -71,6 +72,10 @@ examples/
 - Agent with memory
 - Agent with external API calls
 - Agent with filesystem access
+
+### `github-actions/`
+- A deterministic, side-effect-free LangGraph-style agent
+- A copyable workflow that scans the fixture and uploads SARIF output
 
 ---
 

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,0 +1,21 @@
+# GitHub Actions example
+
+This directory is a small, synthetic LangGraph-style agent used by the
+workflow at `.github/workflows/safeai-example.yml`. The workflow runs SafeAI
+on every push or pull request that changes this example and stores the SARIF
+report as a downloadable artifact.
+
+The fixture is intentionally deterministic and has no credentials, network
+calls, shell commands, or private data. SafeAI analyzes the source statically;
+the workflow never executes the agent.
+
+## Reuse in another repository
+
+1. Copy `agent.py` and this directory's README into the target repository.
+2. Copy `.github/workflows/safeai-example.yml` into the target repository.
+3. Change the `path` input if the fixture lives somewhere else.
+4. Review the `safeai-results.sarif` artifact after each run.
+
+The workflow uses `contents: read` and does not require secrets. A clean scan
+is evidence for human review, not proof that an application is secure,
+compliant, or production-ready.

--- a/examples/github-actions/agent.py
+++ b/examples/github-actions/agent.py
@@ -1,0 +1,23 @@
+"""Small synthetic agent used by the SafeAI GitHub Actions example."""
+
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+
+class AgentState(TypedDict):
+    message: str
+    response: str
+
+
+def respond(state: AgentState) -> AgentState:
+    """Return a deterministic response without external side effects."""
+    return {**state, "response": "The synthetic agent completed successfully."}
+
+
+def build_agent():
+    graph = StateGraph(AgentState)
+    graph.add_node("respond", respond)
+    graph.add_edge(START, "respond")
+    graph.add_edge("respond", END)
+    return graph.compile()


### PR DESCRIPTION
## Summary

- add a deterministic synthetic LangGraph fixture for the Actions example
- add a copyable workflow that scans the fixture and uploads SARIF output
- document reuse, least-privilege permissions, and review boundaries

## Validation

- SafeAI scan of `examples/github-actions` passes with no blocking findings
- workflow YAML assertions pass
- `git diff --check` passes

Closes #51