### PR TITLE
docs: update supported frameworks consistency (Fixes #88)

### DIFF
--- a/FRAMEWORK_SUPPORT.md
+++ b/FRAMEWORK_SUPPORT.md
@@ -40,6 +40,7 @@ we deliberately do not overclaim coverage.
 | LlamaIndex | AST + imports | Agents, tools, indexes, models | RAG, databases, external APIs | Minimal | Experimental |
 | Dify | YAML/JSON + references | Workflows, agents, tools, models | Shell, databases, external APIs | Minimal | Experimental |
 | n8n | Workflow JSON + references | Workflows, nodes, connections | Shell, databases, email, external APIs | Minimal | Experimental |
+| AutoGen | ✔️ | Partial | Minimal | Minimal | Experimental |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Registry & Reports — shared SQLite registry; terminal, JSON, SARIF 2.1.0, HTML
 | LlamaIndex | ✔ | Partial | Minimal | Minimal | Experimental |
 | Dify | ✔ | Minimal | Minimal | Minimal | Experimental |
 | n8n | ✔ | Partial | Minimal | Minimal | Experimental |
+| AutoGen | ✔️ | Partial | Minimal | Minimal | Experimental |
 
 
 ### Framework Support Details


### PR DESCRIPTION
Hi,

This PR fixes issue #88. I have added `AutoGen` to the list of supported frameworks in the following files to ensure consistency:
- `README.md`
- `FRAMEWORK_SUPPORT.md`

Please review and merge. Let me know if any other changes are required.