### PR TITLE
Add AutoGen to supported frameworks docs

### DIFF
--- a/FRAMEWORK_SUPPORT.md
+++ b/FRAMEWORK_SUPPORT.md
@@ -27,7 +27,7 @@ we deliberately do not overclaim coverage.
 |-----------|-----------------|----------------|---------------------|---------------|----------|
 | LangGraph | AST + regex | Nodes, edges, tools, models, memory | Shell, filesystem, memory, planner | Partial | Partial |
 | CrewAI | AST + regex | Agents, tasks, tools, models, memory | Shell, memory, delegations | Partial | Partial |
-| AutoGen | AST + regex | Agents, tools, models | Multi-agent, delegation | Minimal | Experimental |
+| AutoGen | AST + regex | Agents, tools, models | Shell, filesystem, external APIs | Minimal | Experimental |
 | LangChain | AST + metadata + regex | Agents, chains, tools, memory, models | Shell, memory, planner | Partial | Partial |
 | Semantic Kernel | AST + metadata + regex | Workflows, plugins, memory, models, skills | Shell, memory, planner | Partial | Partial |
 | OpenAI Agents SDK | AST + metadata + regex | Agents, tools, handoffs, MCP | Multi-agent, delegation, MCP | Partial | Partial |
@@ -41,7 +41,6 @@ we deliberately do not overclaim coverage.
 | LlamaIndex | AST + imports | Agents, tools, indexes, models | RAG, databases, external APIs | Minimal | Experimental |
 | Dify | YAML/JSON + references | Workflows, agents, tools, models | Shell, databases, external APIs | Minimal | Experimental |
 | n8n | Workflow JSON + references | Workflows, nodes, connections | Shell, databases, email, external APIs | Minimal | Experimental |
-| AutoGen | ✔️ | Partial | Minimal | Minimal | Experimental |
 
 ---
 
@@ -144,11 +143,17 @@ SafeAI detects:
 
 ### Detection Approach
 
-**Priority:** AST → regex fallback
+**Priority:** AST → regex fallback (`safeai/frameworks/autogen/parser.py`)
 
-- **Imports:** Detects `autogen` in Python import statements (e.g., `from autogen import AssistantAgent`)
-- **AST:** Parses `AssistantAgent()`, `UserProxyAgent()`, `register_for_llm()`, `register_function()` calls
-- **Regex fallback:** `AssistantAgent(`, `UserProxyAgent(`, `register_for_llm`, `register_function`
+- **Python only:** non-`.py` paths are ignored
+- **Imports:** import paths that start with `autogen` (for example `from autogen import AssistantAgent`)
+- **Class usage:** `AssistantAgent(` / `UserProxyAgent(` instantiations (word-boundary; not a bare `"autogen"` substring)
+- **Registration:** `register_for_llm` or `register_function` in file content
+- **AST:** parses `AssistantAgent()`, `UserProxyAgent()`, `register_for_llm()`, and `register_function()` calls
+- **Regex fallback:** `AssistantAgent(`, `UserProxyAgent(`, `register_for_llm(`, `register_function(` when AST found no agents or tools
+- **Parse gate:** `parse()` returns no framework result unless at least one agent or registered tool is found — an import-only file is not advertised as an AutoGen project
+
+Detection evidence recorded on a successful parse: `imports:autogen`, `ast:calls`. Parser confidence is 0.85 (`discovery_method: ast+regex_fallback`).
 
 ### Artifacts Discovered
 
@@ -156,13 +161,15 @@ SafeAI detects:
 |----------|-----------|-----------|-------------|
 | Agents | AST `AssistantAgent()`, `UserProxyAgent()` | 0.85 | AutoGen agent definitions |
 | Tools | AST `register_for_llm()`, `register_function()` | 0.80 | Tool registrations |
-| Models | AST model constructor calls | 0.80 | LLM provider references |
+| Models | AST calls whose names include `openai`, `azure`, `bedrock`, or `anthropic` | 0.80 | LLM provider references |
 
 ### Capabilities Discovered
 
-- **Multi-Agent** — Multiple `Agent()` instances with delegation
-- **Delegation** — Agent-to-agent conversation patterns
-- **External APIs** — Model references
+- **External APIs** — model constructor calls matching OpenAI, Azure, Bedrock, or Anthropic (`confidence=0.8`)
+- **Shell** — resolved call names containing `subprocess`, `os.system`, or `popen` (`confidence=0.9`)
+- **Filesystem** — resolved call names containing `open`, `pathlib`, `os.remove`, or `os.write` (`confidence=0.85`)
+
+The adapter does not emit first-class Multi-Agent or Delegation capabilities. `GroupChat` / `GroupChatManager`, `code_execution_config`, and AutoGen 0.4+ `autogen-agentchat` APIs are not extracted as dedicated artifacts.
 
 ### Detection Example
 
@@ -175,8 +182,17 @@ user_proxy = UserProxyAgent("user_proxy", code_execution_config=False)
 
 SafeAI detects:
 - Framework: `autogen`
-- Agents: `assistant`, `user_proxy`
-- Multi-agent delegation pattern
+- Agents: `AssistantAgent`, `UserProxyAgent` (names taken from the call)
+
+### Limitations
+
+- Detection is Python-only and does not read `requirements.txt` / `pyproject.toml` for an `autogen` dependency
+- A file that only imports AutoGen (no agent instantiation or tool registration) is not reported as an AutoGen project
+- `ConversableAgent`, `GroupChat`, `GroupChatManager`, Swarm, and `autogen_agentchat` AgentChat 0.4+ types have no dedicated matchers (a class still named `AssistantAgent` / `UserProxyAgent` will match)
+- `code_execution_config` is not interpreted; code-execution risk is only inferred if shell or filesystem call names appear
+- Shell and filesystem capabilities are heuristic name matches on resolved call identifiers, not AutoGen tool-schema analysis
+- `register_for_llm` / `register_function` detection uses a content substring and can fire on comments or unrelated identifiers
+- Framework-specific risk analysis is minimal (Experimental maturity), consistent with the README Supported Frameworks table
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SafeAI sits before runtime guardrails and red-teaming tools in the security life
 
 | Feature | Description |
 |---------|-------------|
-| **Framework Detection** | Detects and parses 15 AI agent frameworks (AST + config + regex, no mutual exclusion) |
+| **Framework Detection** | Detects and parses 16 AI agent frameworks (AST + config + regex, no mutual exclusion) |
 | **Tool Identity & Access Modes** | Capabilities attributed to named tools (agent / MCP server / skill / tool / workflow node) on an access scale `none < read < write < mutate < execute`; inferred modes are flagged, never overstated |
 | **Capability Discovery** | Maps 19 capability categories (shell, filesystem, network, database, memory, MCP, ...) with evidence, confidence, and provenance |
 | **Capability Escalation Detection** | Per-tool authority diffs between scans (new shell, read→write widening, new MCP server, removed approval gate, ...) — 14 rules, including gating-aware subsumption |
@@ -85,7 +85,7 @@ File Collection — Python, YAML, JSON, .prompt, and .claude configs;
                  prunes VCS, caches, oversized files, and SafeAI's own artifacts
     │
     ▼
-Framework Detection — 15 parsers (AST + config + regex), all run on all files;
+Framework Detection — 16 parsers (AST + config + regex), all run on all files;
                      import graph and dependency manifests
     │
     ▼
@@ -134,14 +134,13 @@ Registry & Reports — shared SQLite registry; terminal, JSON, SARIF 2.1.0, HTML
 | LlamaIndex | ✔ | Partial | Minimal | Minimal | Experimental |
 | Dify | ✔ | Minimal | Minimal | Minimal | Experimental |
 | n8n | ✔ | Partial | Minimal | Minimal | Experimental |
-| AutoGen | ✔️ | Partial | Minimal | Minimal | Experimental |
 
 
 ### Framework Support Details
 
 - **LangGraph** — detects `StateGraph`, `add_edge`, `bind_tools`, nodes, models
 - **CrewAI** — detects `Agent`, `Task`, tools, models
-- **AutoGen** — detects `AssistantAgent`, `UserProxyAgent`, `register_for_llm`, agent delegation
+- **AutoGen** — detects `AssistantAgent`, `UserProxyAgent`, `register_for_llm`, `register_function`, models
 - **LangChain** — detects `AgentExecutor`, `Chain`, `Tool`, `PromptTemplate`, models
 - **Semantic Kernel** — detects `Kernel.invoke`, plugins, functions, skills, memory
 - **OpenAI Agents SDK** — detects `Agent`, tools, handoffs, MCP references


### PR DESCRIPTION
## Summary

AutoGen shipped in v1.9.0 (CHANGELOG, ROADMAP, RELEASE_NOTES) but the reference tables were incomplete or contradictory: a duplicate AutoGen row used the wrong columns, the AutoGen section claimed Multi-Agent/Delegation capabilities the parser does not emit, and README still said "15 frameworks".

This PR documents AutoGen from `safeai/frameworks/autogen/parser.py` (docs only).

## Changes

- **README.md**
  - Keep a single AutoGen row in Supported Frameworks (after CrewAI): Detection ✔, Discovery Partial, Capability/Risk Minimal, Status Experimental
  - Remove the duplicate `✔️` AutoGen row at the end of the table
  - Count 16 parsers in Key Features and How It Works (matches GITHUB_RELEASE.md "Supported Frameworks (16)")
  - Details bullet now lists `AssistantAgent`, `UserProxyAgent`, `register_for_llm`, `register_function`, models
- **FRAMEWORK_SUPPORT.md**
  - Same 16 frameworks as README; AutoGen capability column is Shell, filesystem, external APIs (what the parser actually emits)
  - Remove the misformatted duplicate table row
  - AutoGen section: detection approach, artifacts, capabilities, limitations, and a detection example aligned with the parser (Python-only, import/`AssistantAgent`/`UserProxyAgent`/`register_for_llm`/`register_function`, parse gate, heuristic shell/filesystem/model APIs)

## Acceptance

- [x] README "Supported Frameworks" table includes AutoGen
- [x] `FRAMEWORK_SUPPORT.md` lists the same frameworks as README
- [x] AutoGen section documents detection, artifacts, capabilities, limitations
- [x] No contradictions vs README, FRAMEWORK_SUPPORT.md, and RELEASE_NOTES.md (v1.9.0 AutoGen adapter; Experimental / minimal risk analysis)

Fixes #95
