### PR TITLE
Fix dataflow analyzer rule id casing mismatch

### DIFF
--- a/safeai/analyzers/dataflow/analyzer.py
+++ b/safeai/analyzers/dataflow/analyzer.py
@@ -200,7 +200,7 @@ class DataFlowAnalyzer:
                     continue
                 seen.add(key)
 
-                rule_id = f"DATAFLOW_{prop['sink_type'].upper()}"
+                rule_id = f"DATAFLOW_{prop['sink_type']}"
                 rule = rule_map.get(rule_id, {})
                 findings.append(_finding(
                     rule_id=rule_id,

--- a/tests/test_adapter_dataflow.py
+++ b/tests/test_adapter_dataflow.py
@@ -101,14 +101,14 @@ class TestDataFlowAnalyzer:
         content = "user_input = request.form['input']\nprompt = f'Process: {user_input}'"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_PROMPT" in rule_ids
+        assert "DATAFLOW_prompt" in rule_ids
 
     def test_detects_user_input_to_shell(self):
         analyzer = self._make_analyzer()
         content = "user_input = input('Enter: ')\nos.system(user_input)"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_SHELL" in rule_ids
+        assert "DATAFLOW_shell" in rule_ids
 
     def test_no_finding_without_sources(self):
         analyzer = self._make_analyzer()
@@ -155,7 +155,7 @@ class TestDataFlowAnalyzer:
         content = "test_input = request.form['input']\nos.system(test_input)"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_SHELL" not in rule_ids
+        assert "DATAFLOW_shell" not in rule_ids
 
     def test_placeholder_prefix_example_skipped(self):
         analyzer = self._make_analyzer()
@@ -168,14 +168,14 @@ class TestDataFlowAnalyzer:
         content = "mock_data = request.form['data']\nos.system(mock_data)"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_SHELL" not in rule_ids
+        assert "DATAFLOW_shell" not in rule_ids
 
     def test_non_placeholder_not_skipped(self):
         analyzer = self._make_analyzer()
         content = "user_input = request.form['input']\nos.system(user_input)"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_SHELL" in rule_ids
+        assert "DATAFLOW_shell" in rule_ids
 
     def test_finding_has_confidence_scope_limitation(self):
         analyzer = self._make_analyzer()
@@ -197,4 +197,4 @@ class TestDataFlowAnalyzer:
         content = "test_user = input('Enter: ')\nos.system(test_user)"
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
-        assert "DATAFLOW_SHELL" not in rule_ids
+        assert "DATAFLOW_shell" not in rule_ids


### PR DESCRIPTION
DataFlowAnalyzer builds each finding's rule_id as DATAFLOW_<SINK>.upper() (e.g. DATAFLOW_PROMPT), but base_rules.yaml and controls/mappings.py both use the lowercase sink name (DATAFLOW_prompt). The rule_map lookup in the analyzer never matched, so the yaml's severity/owasp_llm for these six rules never applied — findings always used the analyzer's hardcoded defaults instead.

Dropped the .upper() call and updated the two tests that asserted the old uppercase ids. Full test suite still passes.

Found this while working on #87.