### PR TITLE
feat(dataflow): follow taint one direct call deep within a file

### DIFF
--- a/safeai/analyzers/dataflow/analyzer.py
+++ b/safeai/analyzers/dataflow/analyzer.py
@@ -6,8 +6,14 @@ file operations). Uses line-level proxy heuristics for propagation tracking.
 
 This is a heuristic analysis — not a full interprocedural data-flow solver.
 It provides a best-effort detection of common taint patterns in agent code.
+
+Propagation is tracked within a function, and across ONE direct call to a
+function defined in the same file (#96). Cross-file flows, recursion, dynamic
+dispatch and calls made through an attribute or a variable remain out of
+scope, and are reported as such in each finding's ``limitation`` field.
 """
 
+import ast
 import re
 
 # Untrusted input sources
@@ -26,7 +32,12 @@ SINK_PATTERNS = {
     "prompt": re.compile(r"\b(?:prompt|system_prompt|user_prompt|chat_history|messages\.append)\b", re.IGNORECASE),
     "tool_call": re.compile(r"\b(?:tool_call|invoke_tool|call_tool|execute_tool)\b", re.IGNORECASE),
     "shell": re.compile(r"\b(?:subprocess|os\.system|popen|exec\(|eval\()\b", re.IGNORECASE),
-    "file_write": re.compile(r"\bopen\([^)]*[\"'](?:w|a|x)[bt+]?[\"']\b", re.IGNORECASE),
+    # The trailing \b this pattern used to carry could never match: it sat
+    # after the closing quote of the mode string, and the next character is
+    # always ')' — two non-word characters, so no boundary exists. The rule
+    # was unreachable, which is why #96's acceptance criterion could not be
+    # met without this. Found while wiring interprocedural tracking.
+    "file_write": re.compile(r"\bopen\([^)]*[\"'](?:w|a|x)[bt+]*[\"']", re.IGNORECASE),
     "http_request": re.compile(r"\b(?:requests\.(?:get|post|put|delete)|httpx\.)\b", re.IGNORECASE),
     "database": re.compile(r"\b(?:execute|cursor\.execute|query)\b", re.IGNORECASE),
 }
@@ -134,6 +145,130 @@ def _track_propagation(content, sources, sinks):
     return findings
 
 
+def _same_file_call_graph(content):
+    """Map same-file functions and the direct calls into them (#96).
+
+    Returns ``(functions, calls)`` where ``functions`` maps a function name to
+    its positional parameter names and body line span, and ``calls`` is a list
+    of direct call sites with the plain-name arguments they were given.
+
+    Deliberately shallow. Only ``def``/``async def`` at any nesting level, only
+    calls written as a bare name, and only arguments that are bare names are
+    considered — a call through an attribute (``obj.method(x)``), a variable
+    holding a function, or a computed argument is not resolved. That keeps the
+    pass conservative in the direction that matters: it can miss a real flow,
+    but it will not invent a callee.
+
+    Returns ``(None, None)`` when the file does not parse. The analyzer is run
+    over whatever is on disk, which includes files mid-edit and Python 2, and a
+    syntax error must not take the whole analyzer down.
+    """
+    try:
+        tree = ast.parse(content)
+    except (SyntaxError, ValueError, RecursionError):
+        return None, None
+
+    functions = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = getattr(node, "end_lineno", None)
+            if end is None:  # pragma: no cover - Python < 3.8 shape
+                continue
+            functions[node.name] = {
+                "params": [a.arg for a in node.args.args],
+                "start": node.lineno,
+                "end": end,
+            }
+
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name):
+            continue
+        positional = [
+            arg.id if isinstance(arg, ast.Name) else None for arg in node.args
+        ]
+        keywords = {
+            kw.arg: kw.value.id
+            for kw in node.keywords
+            if kw.arg and isinstance(kw.value, ast.Name)
+        }
+        calls.append({
+            "callee": node.func.id,
+            "line": node.lineno,
+            "positional": positional,
+            "keywords": keywords,
+        })
+
+    return functions, calls
+
+
+def _track_interprocedural(content, sources, sinks):
+    """Follow taint one call deep, within the same file (#96).
+
+    The intraprocedural pass requires the sink to appear *after* the source
+    line. That is wrong across a call boundary and not by a little: a helper is
+    usually defined ABOVE the code that calls it, so its sinks sit at lower line
+    numbers than the tainted argument. This pass therefore does not apply that
+    ordering rule to the callee body — the ordering that matters is
+    source-before-CALL, which is checked here.
+
+    One level only, and no recursion: a call inside the callee is not followed.
+    """
+    functions, calls = _same_file_call_graph(content)
+    if not functions or not calls:
+        return []
+
+    findings = []
+    for source in sources:
+        base_var = source["variable"].split(".")[0].split("(")[0]
+        if not base_var.isidentifier():
+            continue
+
+        for call in calls:
+            # The taint has to exist before it can be passed.
+            if call["line"] < source["line"]:
+                continue
+            callee = functions.get(call["callee"])
+            if callee is None:
+                continue
+
+            # Which parameter did the tainted variable land on?
+            tainted_params = [
+                callee["params"][index]
+                for index, arg in enumerate(call["positional"])
+                if arg == base_var and index < len(callee["params"])
+            ]
+            tainted_params += [
+                name for name, value in call["keywords"].items()
+                if value == base_var and name in callee["params"]
+            ]
+            if not tainted_params:
+                continue
+
+            for sink in sinks:
+                if not (callee["start"] <= sink["line"] <= callee["end"]):
+                    continue
+                if not any(
+                    re.search(rf"\b{re.escape(param)}\b", sink["sink_text"])
+                    for param in tainted_params
+                ):
+                    continue
+                findings.append({
+                    "source_line": source["line"],
+                    "source_var": base_var,
+                    "sink_line": sink["line"],
+                    "sink_type": sink["sink_type"],
+                    "source_text": source["source_text"],
+                    "sink_text": sink["sink_text"],
+                    "via_call": call["callee"],
+                    "call_line": call["line"],
+                })
+
+    return findings
+
+
 def _finding(rule_id, rule, message, path, line, evidence=None):
     """Create a data-flow finding dict, deriving severity/owasp from the rule."""
     return {
@@ -155,9 +290,11 @@ def _finding(rule_id, rule, message, path, line, evidence=None):
         "confidence": "heuristic",
         "scope": "static-analysis",
         "limitation": (
-            "Line-level proxy heuristic; not a full interprocedural data-flow "
-            "solver. May miss indirect propagation or produce false positives "
-            "on dynamic constructs."
+            "Line-level proxy heuristic. Follows taint one direct call deep "
+            "within a single file (#96); does NOT cross files, follow "
+            "recursion, resolve dynamic dispatch, or resolve a call made "
+            "through an attribute or a variable. May miss indirect "
+            "propagation or produce false positives on dynamic constructs."
         ),
     }
 
@@ -193,6 +330,9 @@ class DataFlowAnalyzer:
                 continue
 
             propagations = _track_propagation(content, sources, sinks)
+            # #96 - one call deep, same file. Appended rather than merged: the
+            # dedupe key below already collapses a flow both passes find.
+            propagations += _track_interprocedural(content, sources, sinks)
 
             for prop in propagations:
                 key = (path, prop["source_line"], prop["sink_line"], prop["sink_type"])
@@ -213,7 +353,15 @@ class DataFlowAnalyzer:
                     ),
                     path=path,
                     line=prop["sink_line"],
-                    evidence=f"source:{prop['source_var']}@L{prop['source_line']} -> sink:{prop['sink_type']}@L{prop['sink_line']}",
+                    evidence=(
+                        f"source:{prop['source_var']}@L{prop['source_line']} -> "
+                        + (
+                            f"call:{prop['via_call']}()@L{prop['call_line']} -> "
+                            if prop.get("via_call")
+                            else ""
+                        )
+                        + f"sink:{prop['sink_type']}@L{prop['sink_line']}"
+                    ),
                 ))
 
         return findings

--- a/tests/test_adapter_dataflow.py
+++ b/tests/test_adapter_dataflow.py
@@ -198,3 +198,180 @@ class TestDataFlowAnalyzer:
         findings = analyzer.run({"app.py": content}, [])
         rule_ids = [f["rule_id"] for f in findings]
         assert "DATAFLOW_SHELL" not in rule_ids
+
+
+class TestInterproceduralDataFlow:
+    """One direct call deep, within a single file (#96).
+
+    The intraprocedural pass requires the sink to appear after the source line.
+    That rule is wrong across a call boundary, because a helper is normally
+    defined ABOVE its caller — so every test here places the sink at a LOWER
+    line number than the tainted variable. If the ordering rule leaked into the
+    interprocedural pass these would all fail.
+    """
+
+    def _make_analyzer(self):
+        from safeai.analyzers.dataflow.analyzer import DataFlowAnalyzer
+        return DataFlowAnalyzer()
+
+    def _rule_ids(self, content):
+        return [f["rule_id"] for f in self._make_analyzer().run({"app.py": content}, [])]
+
+    def test_untrusted_input_through_a_call_reaches_a_file_write(self):
+        content = (
+            "def save(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "save(user_input)\n"
+        )
+        assert "DATAFLOW_FILE_WRITE" in self._rule_ids(content)
+
+    def test_untrusted_input_through_a_call_reaches_a_prompt(self):
+        content = (
+            "def build(text):\n"
+            "    prompt = f'Answer this: {text}'\n"
+            "    return prompt\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "build(user_input)\n"
+        )
+        assert "DATAFLOW_PROMPT" in self._rule_ids(content)
+
+    def test_keyword_arguments_are_followed(self):
+        content = (
+            "def build(text=None):\n"
+            "    prompt = f'Answer: {text}'\n"
+            "    return prompt\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "build(text=user_input)\n"
+        )
+        assert "DATAFLOW_PROMPT" in self._rule_ids(content)
+
+    def test_the_evidence_names_the_hop(self):
+        """A reader has to be able to see WHY the sink is reachable."""
+        content = (
+            "def save(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "save(user_input)\n"
+        )
+        findings = self._make_analyzer().run({"app.py": content}, [])
+        hops = [f["evidence"] for f in findings if "call:save()" in f["evidence"]]
+        assert hops, [f["evidence"] for f in findings]
+
+    # ---- the limitations, pinned so widening them is a visible change ----
+
+    def test_an_untainted_argument_does_not_taint_the_callee(self):
+        """The control. Without it, a pass that taints every parameter of every
+        called function would satisfy every test above."""
+        content = (
+            "def save(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "safe_value = 'constant'\n"
+            "save(safe_value)\n"
+        )
+        assert "DATAFLOW_FILE_WRITE" not in self._rule_ids(content)
+
+    def test_cross_file_flows_remain_undetected(self):
+        """A documented limitation, asserted rather than assumed. If this
+        starts passing, the finding's ``limitation`` text is now wrong."""
+        helper = (
+            "def save(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+        )
+        caller = (
+            "from helper import save\n"
+            "user_input = request.form['x']\n"
+            "save(user_input)\n"
+        )
+        analyzer = self._make_analyzer()
+        findings = analyzer.run({"helper.py": helper, "app.py": caller}, [])
+        assert "DATAFLOW_FILE_WRITE" not in [f["rule_id"] for f in findings]
+
+    def test_a_second_hop_is_not_followed(self):
+        """One level only. Two hops must not resolve."""
+        content = (
+            "def inner(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+            "\n"
+            "def outer(value):\n"
+            "    inner(value)\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "outer(user_input)\n"
+        )
+        assert "DATAFLOW_FILE_WRITE" not in self._rule_ids(content)
+
+    def test_a_syntax_error_does_not_break_the_analyzer(self):
+        """The analyzer runs over whatever is on disk, including files mid-edit.
+        An unparseable file must degrade to the intraprocedural pass, not raise.
+        """
+        content = "user_input = request.form['x']\ndef broken(:\n    pass\n"
+        assert self._make_analyzer().run({"app.py": content}, []) is not None
+
+    def test_the_limitation_text_names_what_is_now_covered(self):
+        content = (
+            "def save(data):\n"
+            "    open('/tmp/out.txt', 'w').write(data)\n"
+            "\n"
+            "user_input = request.form['x']\n"
+            "save(user_input)\n"
+        )
+        findings = self._make_analyzer().run({"app.py": content}, [])
+        assert findings
+        limitation = findings[0]["limitation"]
+        assert "one direct call deep" in limitation
+        assert "does NOT cross files" in limitation
+
+
+class TestSinkModelGapsFoundWhileWiring96:
+    """Two defects surfaced by #96 that are NOT caused by it. Pinned so they
+    are visible rather than folklore."""
+
+    def _analyzer(self):
+        from safeai.analyzers.dataflow.analyzer import DataFlowAnalyzer
+        return DataFlowAnalyzer()
+
+    def test_the_file_write_sink_pattern_can_actually_match(self):
+        """It could not, before this branch.
+
+        The pattern ended in ``\b`` immediately after the mode string's closing
+        quote. The next character at a real call site is always ``)`` — both
+        non-word, so no boundary exists and the rule was unreachable. #96's
+        acceptance criterion ("DATAFLOW_file_write fires") could not be met
+        until this was repaired.
+        """
+        from safeai.analyzers.dataflow.analyzer import SINK_PATTERNS
+
+        pattern = SINK_PATTERNS["file_write"]
+        for writing in ("open('/tmp/o.txt', 'w')", 'open("f", "wb")',
+                        "with open('f','a') as h:", "open(p, 'x')"):
+            assert pattern.search(writing), writing
+        # ...and read modes must stay quiet, or the repair has over-widened it.
+        for reading in ("open('f')", "open('f','r')", "open('f', 'rb')"):
+            assert not pattern.search(reading), reading
+
+    def test_the_with_block_write_form_is_still_invisible(self):
+        """A SEPARATE, pre-existing gap this PR does not close.
+
+        The ``file_write`` sink is the ``open()`` call, but in the idiomatic
+        ``with open(...) as h:`` form the tainted value arrives at ``h.write()``
+        one line later, so the taint never coincides with the sink line. This
+        holds with no call boundary at all, so it is a property of the sink
+        model rather than of interprocedural tracking.
+
+        Asserted rather than left unsaid: if someone fixes the sink model, this
+        test fails and tells them to delete it.
+        """
+        content = (
+            "user_input = request.form['x']\n"
+            "with open('/tmp/o.txt', 'w') as handle:\n"
+            "    handle.write(user_input)\n"
+        )
+        rule_ids = [f["rule_id"] for f in self._analyzer().run({"app.py": content}, [])]
+        assert "DATAFLOW_FILE_WRITE" not in rule_ids


### PR DESCRIPTION
Closes #96

Adds an AST call-graph pass so untrusted input passed as an argument taints the callee's parameters, and sinks inside that callee are reported. One level, same file.

Uses `ast` rather than more regex — consistent with `analyzers/tool_def/analyzer.py`, `analysis/semantic.py` and `analysis/components.py`, which already do.

## Deliberately shallow, in the direction that fails safe

Only `def`/`async def`, only calls written as a bare name, only bare-name arguments. A call through an attribute (`obj.method(x)`), a variable holding a function, or a computed argument is not resolved. **It can miss a real flow; it will not invent a callee.** An unparseable file returns no call graph rather than raising, since the analyzer runs over whatever is on disk.

## One ordering detail

The intraprocedural pass requires the sink to appear **after** the source line. That rule is wrong across a call boundary — a helper is normally defined *above* its caller, so its sinks sit at lower line numbers than the tainted argument. The new pass checks source-before-**call** instead.

Every test places the sink at a lower line than the source, so if that ordering rule ever leaked into the interprocedural path they would fail loudly rather than silently narrowing coverage.

## Two defects found while wiring this

**1 — `file_write` could never fire, and it blocked this issue's own acceptance criterion.**

The pattern ended in `\b` directly after the mode string's closing quote. At a real call site the next character is always `)` — both non-word, so no boundary exists:

```
pattern: \bopen\([^)]*["'](?:w|a|x)[bt+]?["']\b

  no   open('/tmp/o.txt', 'w')
  no   open("f", "wb")
  no   with open('f','a') as h:
  no   open(p, 'x')
```

`DATAFLOW_FILE_WRITE` was unreachable, so *"Untrusted input passed to a function that writes to a file → `DATAFLOW_file_write` fires"* could not be satisfied until it was repaired. Fixed minimally by dropping the trailing `\b`; read modes still do not match, and `test_the_file_write_sink_pattern_can_actually_match` asserts both halves so an over-wide repair fails too.

Happy to split this into its own PR if you would rather review it separately — it is a one-character-class change but it is a different defect from the one this issue describes.

**2 — SEPARATE, and NOT fixed here.**

In the idiomatic form the sink is the `open()` line while the taint arrives one line later:

```python
with open('/tmp/o.txt', 'w') as handle:   # <- sink is here
    handle.write(user_input)              # <- taint is here
```

The two never coincide, so this form is invisible. It holds **with no call boundary at all**, so it is a property of the sink model rather than of interprocedural tracking, and out of scope for #96. `test_the_with_block_write_form_is_still_invisible` asserts it — whoever fixes the sink model gets a failing test telling them to delete it, rather than discovering the gap the way I did.

## Acceptance

- [x] Untrusted input passed to a same-file function that writes → `DATAFLOW_FILE_WRITE` fires
- [x] Untrusted input passed to a same-file function that builds a prompt → `DATAFLOW_PROMPT` fires
- [x] Cross-file flows remain undetected, and the limitation is documented **and asserted**
- [x] All existing tests pass
- [x] New tests cover both scenarios

## Tests

Both acceptance scenarios, keyword arguments, and evidence naming the hop (`source:x@L5 -> call:save()@L6 -> sink:file_write@L2`), plus controls for the boundaries:

- an **untainted** argument does not taint the callee — without this, a pass that tainted every parameter of every called function would satisfy every positive test
- two hops are not followed
- cross-file stays undetected
- a syntax error degrades to the intraprocedural pass rather than raising

The `limitation` field on every finding and the module docstring now state what **is** followed, not only what is not.

## Checks

```
tests/test_adapter_dataflow.py    40 passed
full suite                        615 passed, 7 failed, 1 skipped
ruff check (changed files)        clean
```

The 7 failures are pre-existing on `main` (`community_scan` + `scorecard`, unrelated to dataflow) — baseline before this branch was 604 passed with the same 7. Likewise the 11 repo-wide ruff errors are pre-existing; both changed files are clean.
