### PR TITLE
fix(claude_code): resolve permissions by the documented evaluation order

### DIFF
--- a/safeai/analyzers/claude_code/analyzer.py
+++ b/safeai/analyzers/claude_code/analyzer.py
@@ -22,8 +22,9 @@ _REMEDIATION = {
                               "command or path pattern the workflow needs.",
     "CC_BYPASS_PERMISSIONS": "Remove the bypass/auto-approve setting and keep the "
                              "human approval gate enabled in committed settings.",
-    "CC_DENY_SHADOWED": "Narrow the allow entry so the deny entry can take effect, "
-                        "or remove the deny entry that cannot apply.",
+    "CC_DENY_SHADOWED": "Remove the allow entry that cannot apply, or narrow the "
+                        "deny entry if the allow was the intended behaviour. The "
+                        "deny is what takes effect.",
     "CC_FS_WRITE_OUTSIDE_ROOT": "Constrain write grants to paths inside the project root.",
     "CC_SLASH_COMMAND_SHELL": "Pin the command, avoid inline shell in stored "
                               "instructions, and review who can invoke it.",
@@ -204,15 +205,27 @@ class ClaudeCodeAnalyzer:
 
     def _permission_findings(self, records, rule_map):
         findings = []
+        effective = cc_permissions.resolve_effective_rules(records)
         for record in records:
             if record["decision"] == "allow" and record["wildcard"] and record["tool"]:
+                # #93 - a wildcard allow grants nothing the tool's denies do not
+                # already take back, at any scope. Report it, but not as though
+                # the surface were unbounded when it demonstrably is not.
+                constrained = effective.get(str(record["tool"]).lower(), {}).get("decision") == "deny"
                 findings.append(_finding(
                     "CC_WILDCARD_PERMISSION", rule_map,
                     f"Unconstrained Claude Code permission: {record['entry']}",
                     record["path"], record["line"],
                     evidence=record["entry"],
-                    reason=f"{record['tool']} is allowed with no argument constraint, granting "
-                           f"{record['access_mode']} authority over its entire surface.",
+                    reason=(
+                        f"{record['tool']} is allowed with no argument constraint, but a deny "
+                        f"rule for the same tool is evaluated first, so the granted surface is "
+                        f"bounded by that deny."
+                        if constrained else
+                        f"{record['tool']} is allowed with no argument constraint, granting "
+                        f"{record['access_mode']} authority over its entire surface."
+                    ),
+                    severity="medium" if constrained else None,
                 ))
             if cc_permissions.writes_outside_root(record):
                 findings.append(_finding(
@@ -225,14 +238,21 @@ class ClaudeCodeAnalyzer:
                     capability="Filesystem",
                 ))
 
-        for deny, allow in cc_permissions.shadowed_denials(records):
+        # #93 - this finding used to be stated the wrong way round. Claude Code
+        # evaluates deny, then ask, then allow, and "rule specificity doesn't
+        # change the order", so a matching deny ALWAYS decides the call. It is
+        # the allow that is dead configuration, not the deny, and the severity
+        # follows: contradictory rules are a maintenance problem, not a hole.
+        for allow, deny in cc_permissions.ineffective_allows(records):
             findings.append(_finding(
                 "CC_DENY_SHADOWED", rule_map,
-                f"Deny entry is shadowed by a broader allow: {deny['entry']}",
-                deny["path"], deny["line"],
-                evidence=f"deny {deny['entry']} vs allow {allow['entry']}",
-                reason="The deny entry cannot take effect because a broader allow entry covers "
-                       "it, so the configuration reads as safer than it behaves.",
+                f"Allow entry can never apply, a deny covers it: {allow['entry']}",
+                allow["path"], allow["line"],
+                evidence=f"allow {allow['entry']} overridden by deny {deny['entry']}",
+                reason="Claude Code evaluates deny before allow and specificity does not change "
+                       "that, so the deny decides every matching call and this allow widens "
+                       "nothing. The deny is effective; the allow is dead configuration.",
+                severity="low",
             ))
         return findings
 

--- a/safeai/frameworks/claude_code/permissions.py
+++ b/safeai/frameworks/claude_code/permissions.py
@@ -225,11 +225,137 @@ def argument_covers(broad, narrow):
     return False
 
 
-def shadowed_denials(records):
-    """Return ``(deny_record, allow_record)`` pairs where allow wins.
+#: Claude Code's documented rule evaluation order.
+#:
+#: Source: https://code.claude.com/docs/en/permissions
+#:   "Rules are evaluated in order: deny, then ask, then allow. The first match
+#:    in that order determines the outcome, and rule specificity doesn't change
+#:    the order."
+#:
+#: Two consequences this module previously modelled the wrong way round:
+#:
+#: * Specificity is irrelevant. A broad ``Bash(aws *)`` deny blocks a call that
+#:   also matches a narrower ``Bash(aws s3 ls)`` allow — "a deny rule can't
+#:   carry allowlist exceptions".
+#: * Scope is irrelevant. "If a tool is denied at any level, no other level can
+#:   allow it", and "a user-level deny blocks a project-level allow, because
+#:   deny rules from any scope are evaluated before allow rules".
+DECISION_PRECEDENCE = ("deny", "ask", "allow")
 
-    A ``deny`` that a broader ``allow`` contradicts is a false sense of
-    safety, which is worth reporting precisely because it looks safe.
+
+def _broadest(rules):
+    """The rule in ``rules`` that decides the widest set of calls.
+
+    A wildcard argument covers everything, so it wins; otherwise fall back to
+    the shortest argument, which is the most general prefix. Ties break on
+    (path, entry) so the choice is stable across runs.
+    """
+    def sort_key(rule):
+        argument = rule.get("argument")
+        return (
+            0 if _wildcard(argument) else 1,
+            len(str(argument or "")),
+            str(rule.get("path") or ""),
+            str(rule.get("entry") or ""),
+        )
+
+    return min(rules, key=sort_key)
+
+
+def resolve_effective_rules(records):
+    """Return the effective rule per tool, per the documented evaluation order.
+
+    Maps a lowercased tool name to ``{"decision", "rule", "overridden"}``, where
+    ``rule`` is the record that decides the outcome and ``overridden`` lists the
+    records that can never apply because a higher-precedence tier matched first.
+
+    Scope depth is deliberately NOT a parameter. The documentation is explicit
+    that a deny at any level beats an allow at any other, so resolving by scope
+    would model a precedence Claude Code does not implement.
+
+    This answers "which tier decides this tool", not "what happens to one exact
+    command": the argument patterns are matched by
+    :func:`argument_covers`, which is conservative by design.
+    """
+    by_tool = {}
+    for record in records or []:
+        tool = str(record.get("tool") or "").strip().lower()
+        if not tool or record.get("decision") not in DECISION_PRECEDENCE:
+            continue
+        by_tool.setdefault(tool, []).append(record)
+
+    effective = {}
+    for tool, rules in by_tool.items():
+        tiers = {
+            decision: [r for r in rules if r["decision"] == decision]
+            for decision in DECISION_PRECEDENCE
+        }
+        for decision in DECISION_PRECEDENCE:
+            if not tiers[decision]:
+                continue
+            lower = [
+                rule
+                for later in DECISION_PRECEDENCE[DECISION_PRECEDENCE.index(decision) + 1:]
+                for rule in tiers[later]
+            ]
+            effective[tool] = {
+                "decision": decision,
+                "rule": _broadest(tiers[decision]),
+                "overridden": sorted(
+                    lower, key=lambda r: (str(r.get("path") or ""), str(r.get("entry") or ""))
+                ),
+            }
+            break
+    return effective
+
+
+def deny_is_effective(records, deny):
+    """True when ``deny`` decides its tool — which, per the docs, is always.
+
+    Kept as a named predicate rather than inlined ``True`` so the claim is
+    greppable and carries its citation: nothing an allow rule can say, at any
+    scope or any specificity, prevents a matching deny from blocking the call.
+    """
+    tool = str(deny.get("tool") or "").strip().lower()
+    resolved = resolve_effective_rules(records).get(tool)
+    return bool(resolved) and resolved["decision"] == "deny"
+
+
+def ineffective_allows(records):
+    """Return ``(allow_record, deny_record)`` pairs where the ALLOW cannot apply.
+
+    The inverse of what :func:`shadowed_denials` used to claim. An allow whose
+    tool also carries a deny is dead configuration: the deny is evaluated first
+    and its match ends the decision, so the allow widens nothing.
+    """
+    denies = [r for r in records if r.get("decision") == "deny" and r.get("tool")]
+    pairs = []
+    for allow in sorted(
+        (r for r in records if r.get("decision") == "allow" and r.get("tool")),
+        key=lambda r: (str(r.get("path") or ""), str(r.get("entry") or "")),
+    ):
+        for deny in sorted(denies, key=lambda r: (str(r.get("path") or ""), str(r.get("entry") or ""))):
+            if deny["tool"].lower() != allow["tool"].lower():
+                continue
+            if argument_covers(deny["argument"], allow["argument"]):
+                pairs.append((allow, deny))
+                break
+    return pairs
+
+
+def shadowed_denials(records):
+    """Return ``(deny_record, allow_record)`` pairs whose arguments overlap.
+
+    NOTE: an allow never "wins" over a deny. This function used to be
+    documented that way and the finding built on it was inverted. Per
+    :data:`DECISION_PRECEDENCE`, deny is evaluated first and a matching deny
+    ends the decision at any scope and any specificity, so the overlap this
+    reports is a sign the ALLOW is dead configuration — see
+    :func:`ineffective_allows`, which returns the pair the right way round.
+
+    Kept because the overlap itself is still worth surfacing: two rules that
+    contradict each other are a maintenance problem even when the outcome is
+    unambiguous. The severity it carries is decided by the caller.
     """
     allows = [r for r in records if r["decision"] == "allow" and r["tool"]]
     pairs = []

--- a/tests/test_claude_code_deep.py
+++ b/tests/test_claude_code_deep.py
@@ -74,7 +74,6 @@ def test_permissive_project_raises_expected_rules():
     assert rule_ids(report) == {
         "CC_WILDCARD_PERMISSION",
         "CC_BYPASS_PERMISSIONS",
-        "CC_DENY_SHADOWED",
         "CC_FS_WRITE_OUTSIDE_ROOT",
         "CC_HOOK_SHELL_EXEC",
         "CC_MCP_UNCONSTRAINED",
@@ -86,7 +85,6 @@ def test_permissive_project_raises_expected_rules():
     [
         ("CC_WILDCARD_PERMISSION", "high"),
         ("CC_BYPASS_PERMISSIONS", "critical"),
-        ("CC_DENY_SHADOWED", "high"),
         ("CC_FS_WRITE_OUTSIDE_ROOT", "high"),
         ("CC_HOOK_SHELL_EXEC", "high"),
         ("CC_MCP_UNCONSTRAINED", "medium"),
@@ -106,10 +104,25 @@ def test_wildcard_finding_names_the_offending_entry():
     assert "Write(*)" in entries
 
 
-def test_shadowed_deny_identifies_both_sides():
+def test_a_deny_narrower_than_an_allow_is_not_reported():
+    """The permissive fixture is CORRECT configuration, and used to be flagged.
+
+    It carries allow ``Bash(*)`` and deny ``Bash(curl *)``. Claude Code
+    evaluates deny first, so ``curl`` is denied and everything else is allowed
+    — exactly what the two rules say. Neither is dead.
+
+    The old ``CC_DENY_SHADOWED`` fired here at HIGH severity claiming the deny
+    "cannot take effect", which is the opposite of the documented behaviour:
+
+        "Rules are evaluated in order: deny, then ask, then allow. The first
+         match in that order determines the outcome, and rule specificity
+         doesn't change the order."
+        -- https://code.claude.com/docs/en/permissions
+
+    Asserting the absence, so re-introducing the false positive fails here.
+    """
     report = scan("permissive")
-    evidence = findings_for(report, "CC_DENY_SHADOWED")[0]["evidence"]
-    assert "Bash(curl *)" in evidence and "Bash(*)" in evidence
+    assert findings_for(report, "CC_DENY_SHADOWED") == []
 
 
 def test_permissions_carry_tool_identity_and_access_mode():
@@ -370,3 +383,112 @@ def test_monorepo_claude_configs_do_not_overwrite_each_other(tmp_path):
     ids = {f["rule_id"] for f in report["findings"] if f["rule_id"].startswith("CC_")}
     assert "CC_BYPASS_PERMISSIONS" in ids
     assert "CC_WILDCARD_PERMISSION" in ids
+
+
+# ---------------------------------------------------------------------------
+# #93 - the documented evaluation order, pinned against the issue's premise
+# ---------------------------------------------------------------------------
+class TestDocumentedPermissionPrecedence:
+    """Claude Code evaluates deny, then ask, then allow.
+
+    Source: https://code.claude.com/docs/en/permissions
+
+        "Rules are evaluated in order: deny, then ask, then allow. The first
+         match in that order determines the outcome, and rule specificity
+         doesn't change the order."
+
+        "If a tool is denied at any level, no other level can allow it. [...]
+         a user-level deny blocks a project-level allow, because deny rules
+         from any scope are evaluated before allow rules."
+
+    #93 proposed most-specific-match and last-match-wins. Neither exists. Two
+    of its three worked examples expect an allow to win, which cannot happen,
+    so they are inverted here with the citation attached.
+    """
+
+    @staticmethod
+    def _rule(tool, argument, decision, path="settings.json"):
+        return {
+            "tool": tool, "argument": argument, "decision": decision,
+            "path": path, "entry": f"{tool}({argument})", "line": 1,
+        }
+
+    def test_deny_beats_allow_regardless_of_scope(self):
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        records = [
+            self._rule("Bash", "*", "deny", "~/.claude/settings.json"),
+            self._rule("Bash", "rm *", "allow", ".claude/settings.json"),
+        ]
+        assert resolve_effective_rules(records)["bash"]["decision"] == "deny"
+
+    def test_deny_beats_allow_in_the_other_direction_too(self):
+        """The issue's own first case, with the mechanism corrected: the deny
+        wins because deny precedes allow, not because it is more specific."""
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        records = [
+            self._rule("Bash", "*", "allow", "~/.claude/settings.json"),
+            self._rule("Bash", "rm *", "deny", ".claude/settings.json"),
+        ]
+        assert resolve_effective_rules(records)["bash"]["decision"] == "deny"
+
+    def test_specificity_does_not_change_the_order(self):
+        """A broad deny beats a narrow allow -- "a deny rule can't carry
+        allowlist exceptions"."""
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        records = [
+            self._rule("Bash", "aws *", "deny"),
+            self._rule("Bash", "aws s3 ls", "allow"),
+        ]
+        assert resolve_effective_rules(records)["bash"]["decision"] == "deny"
+
+    def test_same_scope_is_not_last_match_wins(self):
+        """#93 expected file order to decide. It does not: deny still wins
+        whichever order the entries appear in."""
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        deny_first = [self._rule("Bash", "*", "deny"), self._rule("Bash", "*", "allow")]
+        allow_first = [self._rule("Bash", "*", "allow"), self._rule("Bash", "*", "deny")]
+        assert resolve_effective_rules(deny_first)["bash"]["decision"] == "deny"
+        assert resolve_effective_rules(allow_first)["bash"]["decision"] == "deny"
+
+    def test_ask_sits_between_deny_and_allow(self):
+        """The tier shadowed_denials never modelled."""
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        records = [self._rule("Bash", "*", "ask"), self._rule("Bash", "*", "allow")]
+        assert resolve_effective_rules(records)["bash"]["decision"] == "ask"
+
+    def test_an_allow_covered_by_a_deny_is_dead_configuration(self):
+        from safeai.frameworks.claude_code.permissions import ineffective_allows
+
+        records = [
+            self._rule("Bash", "*", "deny"),
+            self._rule("Bash", "rm *", "allow"),
+        ]
+        pairs = ineffective_allows(records)
+        assert [(a["entry"], d["entry"]) for a, d in pairs] == [("Bash(rm *)", "Bash(*)")]
+
+    def test_a_narrower_deny_does_not_kill_a_broader_allow(self):
+        """The control. Without it, a pass that called every allow dead
+        whenever any deny existed would satisfy the test above."""
+        from safeai.frameworks.claude_code.permissions import ineffective_allows
+
+        records = [
+            self._rule("Bash", "*", "allow"),
+            self._rule("Bash", "curl *", "deny"),
+        ]
+        assert ineffective_allows(records) == []
+
+    def test_other_tools_are_unaffected(self):
+        from safeai.frameworks.claude_code.permissions import resolve_effective_rules
+
+        records = [
+            self._rule("Bash", "*", "deny"),
+            self._rule("Read", "src/**", "allow"),
+        ]
+        effective = resolve_effective_rules(records)
+        assert effective["bash"]["decision"] == "deny"
+        assert effective["read"]["decision"] == "allow"


### PR DESCRIPTION
Refs #93 — implemented against the documented model, which differs from the issue's premise. Flagging clearly so you can redirect me rather than discover it in the diff.

## Step 1 answered, and it changes the rest

The semantics are neither last-match-wins nor most-specific-match. From [Configure permissions](https://code.claude.com/docs/en/permissions):

> Rules are evaluated in order: deny, then ask, then allow. The first match in that order determines the outcome, **and rule specificity doesn't change the order.**

> A broad deny rule like `Bash(aws *)` blocks every matching call, including calls that also match a narrower allow rule like `Bash(aws s3 ls)`, **so a deny rule can't carry allowlist exceptions.**

> **If a tool is denied at any level, no other level can allow it.** […] a user-level deny blocks a project-level allow, **because deny rules from any scope are evaluated before allow rules.**

Precedence is by rule **type**. Neither scope depth nor specificity enters into it.

| Issue's case | Expected | Documented |
|---|---|---|
| allow `Bash(*)` + deny `Bash(rm *)` → deny effective | ✅ | ✅ right answer, **wrong mechanism** — deny precedes allow, it is not about specificity |
| deny `Bash(*)` + allow `Bash(rm *)` → **allow** effective | | ❌ **deny wins**; an allow cannot override a deny at any level |
| same scope → **last-match wins** | | ❌ **deny wins**; file order is never consulted |

The two inverted cases are implemented the documented way, with the quote in the test docstring so they are not "fixed" back.

## The severity work is bigger than a downgrade — the finding was inverted

`shadowed_denials()` is documented as returning *"pairs where allow wins"*. That cannot happen. `CC_DENY_SHADOWED` fired **on the deny**, saying it *"cannot take effect because a broader allow entry covers it"* — the exact opposite of the real behaviour. Its remediation said *"narrow the allow entry so the deny entry can take effect"*, also backwards.

The deny always takes effect. The **allow** is the dead rule. The finding now reports the allow, at **low** severity: two contradictory rules are a maintenance problem, not a hole.

### This removes a false positive, not just a label

The `permissive` fixture has allow `Bash(*)` and deny `Bash(curl *)`. Deny governs `curl`, allow governs everything else — **both rules do exactly what they say, and the configuration is correct.** It was flagged **HIGH**.

It is now silent, and `test_a_deny_narrower_than_an_allow_is_not_reported` asserts the absence so re-introducing it fails by name.

## What is added

- `resolve_effective_rules(records)` — deciding tier per tool, plus the rules it overrides. Scope depth is deliberately **not** a parameter; resolving by scope would model a precedence that does not exist.
- `ineffective_allows(records)` — the inverse of what `shadowed_denials` claimed.
- `deny_is_effective()` — a greppable carrier for the claim, with its citation, rather than an inlined `True`.
- `CC_WILDCARD_PERMISSION` drops to medium when a deny for the same tool is evaluated first: the surface is bounded by that deny, not unbounded.
- `shadowed_denials()` is kept (the overlap is still worth surfacing) with its false premise corrected in the docstring.

## Tests

Both directions of the documented order, specificity not changing it, same-scope order not changing it, and the **`ask` tier** — which `shadowed_denials` never modelled at all.

Plus a control: `test_a_narrower_deny_does_not_kill_a_broader_allow`. Without it, an implementation that called every allow dead whenever any deny existed would satisfy every other test here.

## Two things for you to decide

1. **The rule ID may now be misnamed.** Under the real model the *allow* is the shadowed rule, so `CC_DENY_SHADOWED` reads backwards. I kept the ID to avoid churning your rule surface and SARIF consumers — say the word and I will rename it.
2. **Whether low severity is right**, or whether it should be informational, or suppressed entirely. The issue said "downgrade or suppress"; I chose the least destructive option.

## Checks

```
tests/test_claude_code_deep.py    53 passed
full suite                        611 passed, 7 failed, 1 skipped
ruff check safeai/ tests/         clean
```

The 7 failures are pre-existing on `main` (`community_scan` + `scorecard`); baseline before this branch was 604 passed with the same 7.

Marked `Refs` rather than `Closes` — items 3–5 are done as described, but since the model changed you may want to re-scope the issue before it closes.
