### PR TITLE
Add rule_coverage_summary() to controls/mappings

### DIFF
--- a/safeai/controls/mappings.py
+++ b/safeai/controls/mappings.py
@@ -260,3 +260,47 @@ def get_framework_summary():
         }
         for fid, f in FRAMEWORKS.items()
     ]
+
+
+def rule_coverage_summary():
+    """Report control-mapping coverage per rule category.
+
+    Groups every built-in rule (from ``rules/base_rules.yaml``) by its
+    category prefix -- the token before the first underscore, e.g. ``CAP``,
+    ``GOV``, ``DATAFLOW`` -- and reports how many rules in that category have
+    a ``RULE_MAPPINGS`` entry and how many do not.
+
+    This is informational only: it is not a compliance or coverage claim,
+    and a "mapped" rule is not weighted by how often it actually fires.
+
+    Returns
+    -------
+    list[dict]
+        One entry per category, sorted by category name, each with
+        ``category``, ``mapped_count``, ``unmapped_count``, and
+        ``unmapped_rules`` (sorted rule IDs).
+    """
+    from safeai.rules.loader import load_rules
+
+    rules, _metadata = load_rules()
+    rule_ids = {r["id"] for r in rules if isinstance(r, dict) and "id" in r}
+    mapped_ids = set(RULE_MAPPINGS)
+
+    by_category = {}
+    for rule_id in rule_ids:
+        category = rule_id.split("_", 1)[0]
+        entry = by_category.setdefault(category, {"mapped": 0, "unmapped": []})
+        if rule_id in mapped_ids:
+            entry["mapped"] += 1
+        else:
+            entry["unmapped"].append(rule_id)
+
+    return [
+        {
+            "category": category,
+            "mapped_count": data["mapped"],
+            "unmapped_count": len(data["unmapped"]),
+            "unmapped_rules": sorted(data["unmapped"]),
+        }
+        for category, data in sorted(by_category.items())
+    ]

--- a/tests/test_control_mappings.py
+++ b/tests/test_control_mappings.py
@@ -125,3 +125,46 @@ class TestControlMappings:
             for framework, control_id in mappings:
                 assert framework in {"owasp_llm", "owasp_agentic", "nist_ai_rmf"}
                 assert isinstance(control_id, str)
+
+
+class TestRuleCoverageSummary:
+    def test_unmapped_rules_are_visible(self):
+        """Issue #89: coverage must surface gaps, not just a mapped count."""
+        from safeai.controls.mappings import rule_coverage_summary
+        summary = rule_coverage_summary()
+
+        by_category = {entry["category"]: entry for entry in summary}
+        # PROMPT_DELIMITER etc. are not in RULE_MAPPINGS as of this test.
+        assert by_category["PROMPT"]["unmapped_count"] >= 1
+        assert "PROMPT_DELIMITER" in by_category["PROMPT"]["unmapped_rules"]
+
+    def test_gov_and_dataflow_are_fully_mapped(self):
+        from safeai.controls.mappings import rule_coverage_summary
+        summary = rule_coverage_summary()
+
+        by_category = {entry["category"]: entry for entry in summary}
+        assert by_category["GOV"]["unmapped_count"] == 0
+        assert by_category["DATAFLOW"]["unmapped_count"] == 0
+
+    def test_counts_match_the_rule_lists(self):
+        from safeai.controls.mappings import rule_coverage_summary
+        for entry in rule_coverage_summary():
+            assert entry["unmapped_count"] == len(entry["unmapped_rules"])
+
+    def test_no_compliance_claim_field(self):
+        """This is informational only -- no field should imply a pass/fail claim."""
+        from safeai.controls.mappings import rule_coverage_summary
+        for entry in rule_coverage_summary():
+            assert set(entry) == {
+                "category", "mapped_count", "unmapped_count", "unmapped_rules",
+            }
+
+    def test_deterministic_and_sorted(self):
+        from safeai.controls.mappings import rule_coverage_summary
+        summary = rule_coverage_summary()
+        categories = [entry["category"] for entry in summary]
+        assert categories == sorted(categories)
+        for entry in summary:
+            assert entry["unmapped_rules"] == sorted(entry["unmapped_rules"])
+        # Calling it twice must produce identical output.
+        assert rule_coverage_summary() == summary


### PR DESCRIPTION
Fixes #89.

`RULE_MAPPINGS` covers a subset of the rules in `base_rules.yaml` — currently GOV_* and DATAFLOW_* are fully mapped, most other categories are partially or not mapped at all — but there was no way to see that without diffing the two by hand.

## Changes

- `rule_coverage_summary()` in `safeai/controls/mappings.py`: loads the built-in rules via the existing `safeai.rules.loader.load_rules()`, groups them by category prefix (`CAP`, `GOV`, `DATAFLOW`, `PROMPT`, ...), and reports `mapped_count` / `unmapped_count` / `unmapped_rules` per category. Sorted output, no compliance-claim field.
- Five new tests in `tests/test_control_mappings.py` covering: unmapped rules are actually visible, GOV/DATAFLOW show zero gaps, counts match the rule lists, the output shape has no pass/fail field, and it's deterministic across calls.

Ran it against current `main` — 3 fully-mapped categories (GOV, DATAFLOW, ENV), the rest showing real gaps (e.g. PROMPT: 1/8 mapped, all ten CC_* rules unmapped, all four MCP_* rules unmapped).

Full suite: 636 passed, 1 skipped, 3 pre-existing failures in `TestInterproceduralDataFlow` unrelated to this change (reproduced on a clean checkout of `main` before my edits).