### PR TITLE
Add .cursorrules config-file adapter

### DIFF
--- a/FRAMEWORK_SUPPORT.md
+++ b/FRAMEWORK_SUPPORT.md
@@ -41,6 +41,7 @@ we deliberately do not overclaim coverage.
 | LlamaIndex | AST + imports | Agents, tools, indexes, models | RAG, databases, external APIs | Minimal | Experimental |
 | Dify | YAML/JSON + references | Workflows, agents, tools, models | Shell, databases, external APIs | Minimal | Experimental |
 | n8n | Workflow JSON + references | Workflows, nodes, connections | Shell, databases, email, external APIs | Minimal | Experimental |
+| Cursor (.cursorrules) | Filename + JSON/YAML/free text | Declared tools, model | Shell, filesystem, external APIs, databases | Minimal | Experimental |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Registry & Reports — shared SQLite registry; terminal, JSON, SARIF 2.1.0, HTML
 | LlamaIndex | ✔ | Partial | Minimal | Minimal | Experimental |
 | Dify | ✔ | Minimal | Minimal | Minimal | Experimental |
 | n8n | ✔ | Partial | Minimal | Minimal | Experimental |
+| Cursor (.cursorrules) | ✔ | Minimal | Minimal | Minimal | Experimental |
 
 
 ### Framework Support Details
@@ -155,6 +156,9 @@ Registry & Reports — shared SQLite registry; terminal, JSON, SARIF 2.1.0, HTML
 - **LlamaIndex** — detects agents, tools, indexes, and model references
 - **Dify** — detects Dify workflow and agent configuration files
 - **n8n** — detects n8n workflow exports, nodes, and connections
+- **Cursor (.cursorrules)** — detects declared tools/permissions and
+  capability-relevant keywords (shell, filesystem, HTTP, database) in the
+  IDE's rules config, JSON, YAML, or free text
 
 Maturity is on the scale defined in [`FRAMEWORK_SUPPORT.md`](FRAMEWORK_SUPPORT.md):
 **Partial** = reliable detection and discovery with capability/risk analysis over

--- a/safeai/engine/orchestrator.py
+++ b/safeai/engine/orchestrator.py
@@ -72,7 +72,9 @@ def _is_scannable_file(filename):
     lower = filename.lower()
     if lower.endswith((".py", ".json", ".yaml", ".yml", ".prompt")):
         return True
-    return lower in {"claude.md", "prompt.md", "system_prompt.md"} or lower.endswith((".prompt.md", ".prompt.txt"))
+    return lower in {
+        "claude.md", "prompt.md", "system_prompt.md", ".cursorrules",
+    } or lower.endswith((".prompt.md", ".prompt.txt"))
 
 
 #: Additional extensions read inside a ``.claude/`` directory. Claude Code

--- a/safeai/frameworks/__init__.py
+++ b/safeai/frameworks/__init__.py
@@ -59,6 +59,7 @@ def discover_parsers(include_external=True):
     from safeai.frameworks.bedrock_agent.parser import BedrockAgentParser  # noqa: F401
     from safeai.frameworks.claude_code.parser import ClaudeCodeParser  # noqa: F401
     from safeai.frameworks.crewai.parser import CrewAIParser  # noqa: F401
+    from safeai.frameworks.cursorrules.parser import CursorRulesParser  # noqa: F401
     from safeai.frameworks.dify.parser import DifyParser  # noqa: F401
     from safeai.frameworks.google_adk.parser import GoogleADKParser  # noqa: F401
     from safeai.frameworks.haystack.parser import HaystackParser  # noqa: F401

--- a/safeai/frameworks/cursorrules/parser.py
+++ b/safeai/frameworks/cursorrules/parser.py
@@ -1,0 +1,156 @@
+"""Cursor IDE (.cursorrules) framework adapter.
+
+Detects the ``.cursorrules`` config file Cursor IDE uses to define agent
+behavior, permissions, and tool access, and extracts the capability-relevant
+signals it declares — mirroring how the Claude Code adapter scans
+``.claude/settings.json``, but for this narrower, single-file config.
+
+``.cursorrules`` has no fixed schema in the wild: some projects write JSON,
+some YAML, and many just write free-text instructions. This adapter tries
+structured parsing first and falls back to scanning the raw text for the
+same capability keywords when the file is neither valid JSON nor YAML.
+"""
+
+import json
+import re
+
+import yaml
+
+from safeai.analysis.capabilities import dedupe_capabilities, make_capability
+from safeai.frameworks import register_parser
+
+# Keys under which a .cursorrules file might declare its instructions and
+# its tool/permission grants. Checked in order; the first present key wins.
+_RULE_TEXT_KEYS = ("rules", "instructions", "prompt", "content")
+_TOOL_KEYS = ("tools", "allowed_tools", "permissions", "allow")
+
+# Same capability vocabulary as the Claude Code adapter's CLAUDE.md fallback
+# (safeai/frameworks/claude_code/parser.py:_parse_claude_md), so a rule
+# mentioning "shell" is scored the same way regardless of which config
+# surface it came from.
+_SHELL_RE = re.compile(r"shell|exec|command|subprocess", re.IGNORECASE)
+_FILESYSTEM_RE = re.compile(r"file|filesystem|read.*file|write.*file", re.IGNORECASE)
+_HTTP_RE = re.compile(r"\bhttp\b|\bapi\b|fetch|request", re.IGNORECASE)
+_DATABASE_RE = re.compile(r"database|\bsql\b|postgres|mysql|mongodb", re.IGNORECASE)
+_MCP_RE = re.compile(r"\bmcp\b|model.context.protocol", re.IGNORECASE)
+
+# A tool/permission grant with no scoping at all.
+_UNRESTRICTED_RE = re.compile(r"^(\*|all|any)$", re.IGNORECASE)
+
+
+def _scan_capabilities(text, caps, evidence_prefix):
+    """Scan free text for capability keywords, appending to *caps*."""
+    if _SHELL_RE.search(text):
+        caps.append(make_capability(
+            "shell", "Shell", "cursorrules",
+            f"{evidence_prefix}: shell reference", confidence=0.7, source="config",
+        ))
+    if _FILESYSTEM_RE.search(text):
+        caps.append(make_capability(
+            "filesystem", "Filesystem", "cursorrules",
+            f"{evidence_prefix}: filesystem reference", confidence=0.7, source="config",
+        ))
+    if _HTTP_RE.search(text):
+        caps.append(make_capability(
+            "external_apis", "External APIs", "cursorrules",
+            f"{evidence_prefix}: HTTP/API reference", confidence=0.6, source="config",
+        ))
+    if _DATABASE_RE.search(text):
+        caps.append(make_capability(
+            "databases", "Databases", "cursorrules",
+            f"{evidence_prefix}: database reference", confidence=0.6, source="config",
+        ))
+
+
+def _load_structured(content):
+    """Try JSON then YAML. Returns a dict, or None if neither parses to one."""
+    try:
+        data = json.loads(content)
+        if isinstance(data, dict):
+            return data
+    except (json.JSONDecodeError, ValueError):
+        pass
+    try:
+        data = yaml.safe_load(content)
+        if isinstance(data, dict):
+            return data
+    except yaml.YAMLError:
+        pass
+    return None
+
+
+@register_parser
+class CursorRulesParser:
+    name = "cursorrules"
+
+    def detect(self, path, content, scan_ctx=None):
+        fname = path.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        return fname == ".cursorrules"
+
+    def parse(self, path, content, scan_ctx=None):
+        result = {
+            "framework": "cursorrules",
+            "agents": [],
+            "tools": [],
+            "workflows": [],
+            "models": [],
+            "mcp_assets": [],
+            "capabilities": [],
+            "relationships": [],
+            "discovery_method": "filename",
+            "parser_confidence": 0.75,
+            "detection_evidence": [".cursorrules"],
+        }
+
+        caps = []
+        data = _load_structured(content)
+        if data is not None:
+            self._parse_structured(data, result, caps)
+        else:
+            self._parse_freeform(content, result, caps)
+
+        if _MCP_RE.search(content):
+            result["mcp_assets"].append({"type": "reference", "source": ".cursorrules"})
+
+        result["capabilities"] = dedupe_capabilities(caps)
+        return result
+
+    def _parse_structured(self, data, result, caps):
+        result["discovery_method"] = "config"
+
+        rule_text_parts = []
+        for key in _RULE_TEXT_KEYS:
+            val = data.get(key)
+            if isinstance(val, str):
+                rule_text_parts.append(val)
+            elif isinstance(val, list):
+                rule_text_parts.extend(str(v) for v in val)
+        rule_text = "\n".join(rule_text_parts)
+        if rule_text:
+            _scan_capabilities(rule_text, caps, "rules")
+
+        tool_names = []
+        for key in _TOOL_KEYS:
+            val = data.get(key)
+            if isinstance(val, str):
+                tool_names.append(val)
+            elif isinstance(val, list):
+                tool_names.extend(str(v) for v in val)
+            elif isinstance(val, dict):
+                tool_names.extend(str(k) for k in val)
+        for tool in tool_names:
+            result["tools"].append(tool)
+        # An unscoped grant ("*"/"all"/"any", with no per-tool restriction)
+        # is itself the governance-relevant signal: whatever the rule text
+        # already implied is unrestricted by any accompanying deny/allowlist.
+        # Recorded as a tool identity so a reviewer sees it declared plainly,
+        # rather than guessed at through a synthetic capability.
+        if any(_UNRESTRICTED_RE.match(t.strip()) for t in tool_names):
+            result["detection_evidence"].append("unrestricted tool grant (no per-tool scoping)")
+
+        if "model" in data:
+            result["models"].append(str(data["model"]))
+
+    def _parse_freeform(self, content, result, caps):
+        result["discovery_method"] = "content"
+        _scan_capabilities(content, caps, "freeform rules")

--- a/tests/fixtures/cursorrules/representative/.cursorrules
+++ b/tests/fixtures/cursorrules/representative/.cursorrules
@@ -1,0 +1,9 @@
+{
+  "rules": [
+    "You are a senior backend engineer working on this repository.",
+    "You may run shell commands to execute tests and inspect file contents.",
+    "Call the internal HTTP API to fetch ticket data when needed."
+  ],
+  "tools": ["read_file", "run_tests"],
+  "model": "claude-sonnet-4-5"
+}

--- a/tests/test_cursorrules_framework.py
+++ b/tests/test_cursorrules_framework.py
@@ -1,0 +1,112 @@
+import os
+
+from safeai.engine.scan import run_scan
+from safeai.frameworks.cursorrules.parser import CursorRulesParser
+
+FIXTURE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "cursorrules", "representative"
+)
+
+
+def test_representative_cursorrules_file_is_detected_and_parsed():
+    report = run_scan(FIXTURE)
+
+    assert "cursorrules" in report["detected_frameworks"]
+    model = next(
+        model
+        for model in report["unified_models"]
+        if "cursorrules" in model.get("frameworks", [])
+    )
+    artifacts = model["artifacts"]
+
+    assert {tool["name"] for tool in artifacts["tools"]} == {
+        "read_file", "run_tests",
+    }
+    assert "claude-sonnet-4-5" in {
+        model_entry["name"] for model_entry in artifacts["models"]
+    }
+
+    capability_names = {
+        capability["name"] for capability in model["capabilities"]
+    }
+    assert {"shell", "external_apis"}.issubset(capability_names)
+
+
+class TestDetect:
+    def test_detects_dotfile_by_name(self):
+        parser = CursorRulesParser()
+        assert parser.detect(".cursorrules", "{}") is True
+
+    def test_detects_dotfile_in_subdirectory(self):
+        parser = CursorRulesParser()
+        assert parser.detect("/repo/nested/.cursorrules", "{}") is True
+
+    def test_ignores_unrelated_file(self):
+        parser = CursorRulesParser()
+        assert parser.detect("README.md", "some content") is False
+
+    def test_ignores_similarly_named_file(self):
+        parser = CursorRulesParser()
+        assert parser.detect("cursorrules.json", "{}") is False
+
+
+class TestParseJSON:
+    def test_extracts_tools_and_model(self):
+        parser = CursorRulesParser()
+        content = '{"tools": ["run_tests"], "model": "gpt-5"}'
+        result = parser.parse(".cursorrules", content)
+        assert result["framework"] == "cursorrules"
+        assert "run_tests" in result["tools"]
+        assert "gpt-5" in result["models"]
+
+    def test_shell_mention_in_rules_yields_shell_capability(self):
+        parser = CursorRulesParser()
+        content = '{"rules": ["You may run shell commands freely."]}'
+        result = parser.parse(".cursorrules", content)
+        names = {c["name"] for c in result["capabilities"]}
+        assert "shell" in names
+
+    def test_unrestricted_tool_grant_is_flagged_in_evidence(self):
+        parser = CursorRulesParser()
+        content = '{"tools": ["*"]}'
+        result = parser.parse(".cursorrules", content)
+        assert any("unrestricted" in e for e in result["detection_evidence"])
+
+
+class TestParseYAML:
+    def test_extracts_tools_from_yaml(self):
+        parser = CursorRulesParser()
+        content = "tools:\n  - read_file\n  - write_file\nmodel: claude-opus-4\n"
+        result = parser.parse(".cursorrules", content)
+        assert set(result["tools"]) == {"read_file", "write_file"}
+        assert "claude-opus-4" in result["models"]
+
+    def test_filesystem_mention_in_yaml_rules_yields_filesystem_capability(self):
+        parser = CursorRulesParser()
+        content = "rules:\n  - You may read and write file contents in this repo.\n"
+        result = parser.parse(".cursorrules", content)
+        names = {c["name"] for c in result["capabilities"]}
+        assert "filesystem" in names
+
+
+class TestParseFreeform:
+    def test_plain_text_falls_back_to_content_scan(self):
+        parser = CursorRulesParser()
+        content = "You are an assistant. You may run shell commands to build the project."
+        result = parser.parse(".cursorrules", content)
+        assert result["discovery_method"] == "content"
+        names = {c["name"] for c in result["capabilities"]}
+        assert "shell" in names
+
+    def test_plain_text_with_no_capability_keywords_yields_no_capabilities(self):
+        parser = CursorRulesParser()
+        content = "Always write concise commit messages and prefer clarity."
+        result = parser.parse(".cursorrules", content)
+        assert result["capabilities"] == []
+
+
+def test_mcp_reference_is_recorded_as_asset():
+    parser = CursorRulesParser()
+    content = '{"rules": ["This project uses MCP servers for tool access."]}'
+    result = parser.parse(".cursorrules", content)
+    assert len(result["mcp_assets"]) == 1


### PR DESCRIPTION
Fixes #105.

First adapter in the config-file scanning workstream (ROADMAP.md v2.0.0), following the Claude Code adapter's pattern.

## Changes

- `safeai/frameworks/cursorrules/parser.py`: `CursorRulesParser`, registered via `@register_parser`. Detects `.cursorrules` by filename. Tries JSON then YAML for structured parsing (extracts `tools`/`allowed_tools`/`permissions`/`allow` into `result["tools"]`, `model` into `result["models"]`, and scans any `rules`/`instructions`/`prompt`/`content` text for capability keywords); falls back to scanning the raw file text when it's neither valid JSON nor YAML, since real `.cursorrules` files are often just free-text instructions. An unscoped grant (`"*"`/`"all"`/`"any"` with no per-tool restriction) is recorded in `detection_evidence` rather than mapped to a synthetic capability that doesn't cleanly fit the existing `CAP_*` vocabulary.
- Capability keywords (shell/filesystem/HTTP/database) reuse the same vocabulary the Claude Code adapter's CLAUDE.md fallback already uses, so a rule mentioning "shell" scores the same regardless of which config surface it came from.
- **`safeai/engine/orchestrator.py`**: added `.cursorrules` to `_is_scannable_file()`'s allowlist. Without this the file is never read into `file_cache` at all, so `detect()` never runs — found this by testing end-to-end with `run_scan()` rather than only unit-testing the parser class directly.
- `safeai/frameworks/__init__.py`: import + register in `discover_parsers()`. (Note: `HOW_TO_ADD_FRAMEWORK.md` step 3 says to register in `safeai/engine/scan.py` — that's stale, the real registration point is here, which is what `orchestrator.py` actually calls.)
- `README.md` / `FRAMEWORK_SUPPORT.md`: added to the framework support tables.
- `tests/test_cursorrules_framework.py`: an end-to-end `run_scan()` test against a fixture, plus unit tests for `detect()`/`parse()` covering JSON, YAML, free-text fallback, the unrestricted-grant case, and MCP-reference detection. `tests/fixtures/cursorrules/representative/.cursorrules` is the fixture.

## Verification

Ran the real CLI against the fixture — correctly reports framework `cursorrules` and the expected capability findings:

```
Frameworks: cursorrules
[high] cursorrules:1 - Capability discovered: shell
[medium] cursorrules:1 - Capability discovered: filesystem
[medium] cursorrules:1 - Capability discovered: external_apis
```

Full suite: 644 passed, 1 skipped, 3 pre-existing failures in `TestInterproceduralDataFlow` unrelated to this change (reproduced on a clean `main` checkout before my edits). `ruff check` clean on all changed/new files.