### PR TITLE
feat(schema): add evidence_type to every finding

### DIFF
--- a/KYA_MANIFEST.md
+++ b/KYA_MANIFEST.md
@@ -25,6 +25,7 @@ registry, JSON output, capability/agent comparison, and future integrations.
 | 1.0 | Initial manifest: `agents`, `components`, `findings`, `summary`, `limitations` |
 | 1.1 | `tool_surface` — the per-tool capability index described below |
 | 1.2 | `assurance_boundary` — the verified/not-verifiable statement described below |
+| 1.3 | `evidence_type` on every finding — declared vs matched vs executed |
 
 Both 1.1 and 1.2 are purely additive: a 1.0 consumer that ignores unknown
 fields reads a 1.2 manifest without error.
@@ -183,6 +184,28 @@ reflection of this run rather than boilerplate. Read this alongside
 | `provenance` | `{analyzer, heuristic, evidence[]}` — evidence is redacted |
 | `location` | `{path, line_start, line_end}` — project-relative |
 | `status` | `new` \| `existing` \| `regressed` \| `resolved` \| `suppressed` \| `unknown` |
+| `evidence_type` | `static-config` \| `static-pattern` \| `runtime-observed` — how the finding was arrived at (see below) |
+
+### `evidence_type`
+
+The [assurance boundary](#assurance-boundary) says what a static scan can and
+cannot claim overall. `evidence_type` carries the same distinction on each
+individual finding, so a consumer can tell what was *declared* from what was
+*matched* from what was actually *executed* without inferring it from the
+analyzer's name.
+
+| Value | Means | Emitted by |
+|---|---|---|
+| `static-config` | Read out of source or configuration the project declares — a permission entry, a model kwarg, an MCP server block. Carries the certainty of a parsed field. | `claude_code`, `model_config`, `mcp`, `governance`, `workflow`, `skill`, `tool_def`, `env_dependency` |
+| `static-pattern` | Matched by a pattern against text. Carries the false-positive profile of a regex, not of a parsed field. | `capability`, `dataflow`, `prompt`, `prompt_file`, `data_leakage` |
+| `runtime-observed` | Recorded from an execution. **Nothing emits this today** — it is defined so a future runtime integration does not have to widen the schema, and so its absence is visible rather than implied. | — |
+
+The value is set explicitly at every finding site rather than defaulted
+centrally: a default would silently label a new analyzer's findings
+`static-config` when nobody chose that. `test_every_finding_carries_a_valid_evidence_type`
+fails instead.
+
+Surfaced in the JSON report and in SARIF `properties`.
 
 ## Fingerprint Algorithm
 

--- a/safeai/analyzers/capability/analyzer.py
+++ b/safeai/analyzers/capability/analyzer.py
@@ -72,6 +72,7 @@ CATEGORY_BY_CAP = {
 def _finding(rule_id, rule, message, path, line, capability, framework="generic", evidence=None, confidence=0.6, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-pattern",  # #94 - regex fallback pass over raw file content
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,
@@ -160,6 +161,7 @@ class CapabilityAnalyzer:
 
             findings.append({
                 "rule_id": rule_id,
+                "evidence_type": "static-pattern",  # #94 - regex fallback pass over raw file content
                 "severity": rule.get("severity", "medium"),
                 "message": f"Capability discovered: {cap_name}",
                 "file": path,
@@ -249,6 +251,7 @@ class CapabilityAnalyzer:
                         rule = rule_map.get("CAP_AUTONOMY", {})
                         findings.append({
                             "rule_id": "CAP_AUTONOMY",
+                            "evidence_type": "static-pattern",  # #94 - regex fallback pass over raw file content
                             "severity": rule.get("severity", "high"),
                             "message": "Potential autonomous agent loop detected",
                             "file": path,

--- a/safeai/analyzers/claude_code/analyzer.py
+++ b/safeai/analyzers/claude_code/analyzer.py
@@ -99,6 +99,7 @@ def _finding(rule_id, rule_map, message, path, line, evidence, reason, severity=
     resolved = severity or rule.get("severity") or _DEFAULT_SEVERITY.get(rule_id, "medium")
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reads declared permission/hook/settings entries
         "severity": resolved,
         "message": message,
         "file": path,

--- a/safeai/analyzers/data_leakage/analyzer.py
+++ b/safeai/analyzers/data_leakage/analyzer.py
@@ -94,6 +94,7 @@ class DataLeakageAnalyzer:
                         )
                         findings.append({
                             "rule_id": "DATA_LEAKAGE",
+                            "evidence_type": "static-pattern",  # #94 - regex patterns over source text
                             "severity": severity,
                             "message": f"Potential secret exposure: {key}",
                             "file": path,

--- a/safeai/analyzers/dataflow/analyzer.py
+++ b/safeai/analyzers/dataflow/analyzer.py
@@ -273,6 +273,7 @@ def _finding(rule_id, rule, message, path, line, evidence=None):
     """Create a data-flow finding dict, deriving severity/owasp from the rule."""
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-pattern",  # #94 - line-level taint heuristic over source text
         "severity": rule.get("severity", "high"),
         "message": message,
         "file": path,

--- a/safeai/analyzers/env_dependency/analyzer.py
+++ b/safeai/analyzers/env_dependency/analyzer.py
@@ -186,6 +186,7 @@ def _wrap_inventory(inventory, rules):
     rule = rule_map.get(INVENTORY_RULE_ID, {})
     return [{
         "rule_id": INVENTORY_RULE_ID,
+        "evidence_type": "static-config",  # #94 - inventories declared config references, names only
         "severity": rule.get("severity", "info"),
         "message": f"Referenced {len(inventory)} external configuration/credential names",
         "file": "<scan>",

--- a/safeai/analyzers/governance/analyzer.py
+++ b/safeai/analyzers/governance/analyzer.py
@@ -117,6 +117,7 @@ def _finding(rule_id, rule, message, path, line, tool_name=None, evidence=None, 
         remediation = rule.get("remediation") or "Add the missing governance control to this tool."
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reports a declared control being absent
         "severity": sev,
         "message": message,
         "file": path,

--- a/safeai/analyzers/mcp/analyzer.py
+++ b/safeai/analyzers/mcp/analyzer.py
@@ -87,6 +87,7 @@ def _base_finding(
 ):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reads declared MCP server and tool entries
         "severity": severity,
         "message": message,
         "file": path,
@@ -559,6 +560,7 @@ class MCPAnalyzer:
 
         findings.append({
             "rule_id": "MCP_ASSETS_DISCOVERED",
+            "evidence_type": "static-config",  # #94 - reads declared MCP server and tool entries
             "severity": "info",
             "message": f"Discovered MCP assets: {len(assets)}",
             "file": "<scan>",

--- a/safeai/analyzers/model_config/analyzer.py
+++ b/safeai/analyzers/model_config/analyzer.py
@@ -30,6 +30,7 @@ _REQUIRED_SAFETY_KEYS = {
 def _base_finding(rule_id, rule, message, path, line, evidence=None, reason=None, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reads declared model kwargs
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,

--- a/safeai/analyzers/prompt/analyzer.py
+++ b/safeai/analyzers/prompt/analyzer.py
@@ -61,6 +61,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
                 rule = rule_map.get("PROMPT_INJECTION", {})
                 findings.append({
                     "rule_id": "PROMPT_INJECTION",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": rule.get("severity", "critical"),
                     "message": "Untrusted input interpolated into prompt",
                     "file": path,
@@ -79,6 +80,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if "system" in line.lower() and UNTRUSTED.search(line) and "+" in line:
                 findings.append({
                     "rule_id": "PROMPT_DELIMITER",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "high",
                     "message": "Possible missing delimiter between system and user content",
                     "file": path,
@@ -96,6 +98,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if "system prompt" in line.lower() or "reveal system" in line.lower():
                 findings.append({
                     "rule_id": "PROMPT_SYSTEM_LEAK",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": rule_map.get("PROMPT_SYSTEM_LEAK", {}).get("severity", "high"),
                     "message": "Possible system prompt leakage",
                     "file": path,
@@ -113,6 +116,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if "ignore previous instructions" in line.lower() or "override system" in line.lower():
                 findings.append({
                     "rule_id": "PROMPT_ROLE_OVERRIDE",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": rule_map.get("PROMPT_ROLE_OVERRIDE", {}).get("severity", "high"),
                     "message": "Role override attempt detected",
                     "file": path,
@@ -135,6 +139,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
                     and _has_multiline_concat(lines, i - 1)):
                 findings.append({
                     "rule_id": "PROMPT_MULTI_LINE_CONCAT",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "medium",
                     "message": "Multi-line prompt concatenation detected",
                     "file": path,
@@ -153,6 +158,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if _PROMPT_FILE_INTERP.search(line) and any(kw in line.lower() for kw in ("prompt", "system", "message")):
                 findings.append({
                     "rule_id": "PROMPT_CROSS_FILE_INTERP",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "medium",
                     "message": "Prompt content loaded from external file",
                     "file": path,
@@ -171,6 +177,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if _INDIRECT_INJECTION.search(line) and any(kw in line.lower() for kw in ("prompt", "system", "message", "user")):
                 findings.append({
                     "rule_id": "PROMPT_INDIRECT_INJECTION",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "medium",
                     "message": "Tool call pattern detected near prompt context",
                     "file": path,
@@ -189,6 +196,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
             if _XML_TAG_INJECTION.search(line):
                 findings.append({
                     "rule_id": "PROMPT_XML_INJECTION",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "low",
                     "message": "XML/HTML tag pattern detected in prompt context",
                     "file": path,
@@ -209,6 +217,7 @@ def analyze_prompt_text(path, content, rule_map=None, framework="generic"):
                     and any(kw in line.lower() for kw in ("system", "prompt", "instruction", "ignore"))):
                 findings.append({
                     "rule_id": "PROMPT_TEMPLATE_INJECTION",
+                    "evidence_type": "static-pattern",  # #94 - regex patterns over prompt text
                     "severity": "medium",
                     "message": "Template variable in prompt file may enable injection",
                     "file": path,

--- a/safeai/analyzers/prompt_file/analyzer.py
+++ b/safeai/analyzers/prompt_file/analyzer.py
@@ -45,6 +45,7 @@ _INJECTION_PRONE_RE = re.compile(
 def _base_finding(rule_id, rule, message, path, line, evidence=None, reason=None, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-pattern",  # #94 - regex patterns over prompt files
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,

--- a/safeai/analyzers/skill/analyzer.py
+++ b/safeai/analyzers/skill/analyzer.py
@@ -32,6 +32,7 @@ _CAPABILITY_KEYS = {"capabilities", "tools", "actions", "functions", "operations
 def _base_finding(rule_id, rule, message, path, line, evidence=None, reason=None, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reads declared skill frontmatter
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,

--- a/safeai/analyzers/tool_def/analyzer.py
+++ b/safeai/analyzers/tool_def/analyzer.py
@@ -25,6 +25,7 @@ _PERMISSION_KEYWORDS = {"permission", "permissions", "allowed", "scope", "scopes
 def _base_finding(rule_id, rule, message, path, line, evidence=None, reason=None, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - parses tool definitions from the AST
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,

--- a/safeai/analyzers/workflow/analyzer.py
+++ b/safeai/analyzers/workflow/analyzer.py
@@ -22,6 +22,7 @@ _VALIDATION_RE = re.compile(r"validat|check|verify|sanitiz|assert", re.IGNORECAS
 def _base_finding(rule_id, rule, message, path, line, evidence=None, reason=None, score_contribution=8):
     return {
         "rule_id": rule_id,
+        "evidence_type": "static-config",  # #94 - reads declared workflow/graph structure
         "severity": rule.get("severity", "medium"),
         "message": message,
         "file": path,

--- a/safeai/kya/assurance.py
+++ b/safeai/kya/assurance.py
@@ -11,6 +11,32 @@ file types, real parse failures, real inference counts. Nothing is a
 fixed disclaimer string, because a fixed string stops being read.
 """
 
+#: How a finding was arrived at (#94).
+#:
+#: The assurance boundary below says what a static scan can and cannot claim.
+#: These values put the same distinction on each individual finding, so a
+#: consumer such as AgentKey can tell what was *declared* from what was
+#: *matched* from what was actually *executed*, rather than inferring it from
+#: the analyzer's name.
+#:
+#: * ``static-config``  — read out of source or configuration the project
+#:   declares: a permission entry, a model kwarg, an MCP server block.
+#: * ``static-pattern`` — matched by a pattern against text. Carries the
+#:   false-positive profile of a regex, not the certainty of a parsed field.
+#: * ``runtime-observed`` — recorded from an execution. Nothing emits this
+#:   today; it exists so a future runtime integration does not have to widen
+#:   the schema, and so its absence is visible rather than implied.
+EVIDENCE_STATIC_CONFIG = "static-config"
+EVIDENCE_STATIC_PATTERN = "static-pattern"
+EVIDENCE_RUNTIME_OBSERVED = "runtime-observed"
+
+EVIDENCE_TYPES = (
+    EVIDENCE_STATIC_CONFIG,
+    EVIDENCE_STATIC_PATTERN,
+    EVIDENCE_RUNTIME_OBSERVED,
+)
+
+
 #: Claims a static scan can support. Stable across runs; these describe
 #: the analysis SafeAI performs, not the contents of any one repository.
 VERIFIED_STATICALLY = (

--- a/safeai/report/sarif.py
+++ b/safeai/report/sarif.py
@@ -66,6 +66,7 @@ def write_sarif(report, path):
             "score_contribution",
             "confidence",
             "confidence_label",
+            "evidence_type",
             "resolved_definition",
             "schema_version",
             "validation_rule",

--- a/tests/test_evidence_type.py
+++ b/tests/test_evidence_type.py
@@ -1,0 +1,86 @@
+"""Every finding declares how it was arrived at (#94).
+
+The assurance boundary says what a static scan can claim overall;
+``evidence_type`` says it per finding, so a consumer can separate what was
+*declared* from what was *matched* from what was actually *executed*.
+
+The point of testing it at the analyzer level rather than on a sample report is
+that a NEW analyzer which forgets the field fails here. A central default would
+have made that same omission silently claim `static-config`, which is the
+stronger of the two static values.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+from safeai.kya.assurance import EVIDENCE_TYPES
+
+_ANALYZER_DIR = pathlib.Path(__file__).resolve().parents[1] / "safeai" / "analyzers"
+_RULE_ID = re.compile(r'"rule_id":')
+_EVIDENCE = re.compile(r'"evidence_type":\s*"([a-z-]+)"')
+
+
+def _analyzer_files():
+    return sorted(
+        path for path in _ANALYZER_DIR.glob("*/analyzer.py")
+        if _RULE_ID.search(path.read_text(encoding="utf-8"))
+    )
+
+
+def test_there_are_analyzers_to_check():
+    """Guard the guard: a glob that matched nothing would pass everything."""
+    assert len(_analyzer_files()) >= 13
+
+
+@pytest.mark.parametrize(
+    "path", _analyzer_files(), ids=lambda p: p.parent.name
+)
+def test_every_finding_carries_a_valid_evidence_type(path):
+    text = path.read_text(encoding="utf-8")
+    rule_sites = len(_RULE_ID.findall(text))
+    values = _EVIDENCE.findall(text)
+
+    assert len(values) == rule_sites, (
+        f"{path.parent.name}: {rule_sites} finding site(s) but "
+        f"{len(values)} evidence_type value(s) - every finding must declare one"
+    )
+    for value in values:
+        assert value in EVIDENCE_TYPES, f"{path.parent.name}: unknown value {value!r}"
+
+
+def test_runtime_observed_is_defined_but_unused():
+    """It exists for a future integration. If something starts emitting it,
+    that is a real capability change and this test should be the thing that
+    makes someone say so out loud."""
+    emitted = set()
+    for path in _analyzer_files():
+        emitted.update(_EVIDENCE.findall(path.read_text(encoding="utf-8")))
+
+    assert "runtime-observed" in EVIDENCE_TYPES
+    assert "runtime-observed" not in emitted, (
+        "an analyzer now claims runtime-observed evidence; static analysis "
+        "cannot support that claim - see the assurance boundary"
+    )
+
+
+def test_evidence_type_reaches_sarif_properties(tmp_path):
+    """The field is only useful if it survives into the artifact consumers read."""
+    import json
+
+    from safeai.report.sarif import write_sarif
+
+    report = {"findings": [{
+        "rule_id": "TEST_RULE", "severity": "low", "message": "m",
+        "file": "a.py", "line": 1, "owasp_llm": "LLM01",
+        "evidence_type": "static-pattern",
+    }]}
+    out = tmp_path / "out.sarif"
+    write_sarif(report, str(out))
+
+    doc = json.loads(out.read_text(encoding="utf-8"))
+    props = doc["runs"][0]["results"][0].get("properties", {})
+    assert props.get("evidence_type") == "static-pattern"


### PR DESCRIPTION
Closes #94

Findings didn't say **how** they were arrived at, so a consumer like AgentKey couldn't separate what a project *declares* from what a regex *matched* from what was actually *executed* — the distinction `assurance.py` already draws at the report level, but not per finding.

## The three values

Defined in `kya/assurance.py`, next to the boundary they refine:

| Value | Means | Emitted by |
|---|---|---|
| `static-config` | Read out of declared source or configuration — a permission entry, a model kwarg, an MCP server block. Carries the certainty of a parsed field. | `claude_code`, `model_config`, `mcp`, `governance`, `workflow`, `skill`, `tool_def`, `env_dependency` |
| `static-pattern` | Matched by a pattern against text. Carries a regex's false-positive profile, not a parsed field's. | `capability`, `dataflow`, `prompt`, `prompt_file`, `data_leakage` |
| `runtime-observed` | Recorded from an execution. **Nothing emits it.** | — |

`capability` is `static-pattern` because its finding-producing path is the regex fallback pass over raw content, per its own docstring — happy to move any of these if you read a boundary differently.

## Set explicitly, not defaulted

All **24 finding sites across all 13 analyzers**, each with its reason inline.

A central default was the obvious shortcut and I think it's the wrong one: it would make a future analyzer's omission silently claim `static-config`, the stronger of the two static values. Instead `test_every_finding_carries_a_valid_evidence_type` compares the count of `"rule_id"` sites against the count of `evidence_type` values **per file**, so a missed site fails by analyzer name.

There's also a guard on the guard — `test_there_are_analyzers_to_check` — because a glob that matched nothing would have passed everything.

## `runtime-observed` is defined but unused, and asserted so

It exists so a future runtime integration doesn't have to widen the schema, and so its absence is *visible rather than implied*. `test_runtime_observed_is_defined_but_unused` fails if an analyzer starts claiming it — that would be a real capability change, and static analysis cannot support the claim.

## Surfaced

Added to the SARIF `properties` passthrough. The test writes a real `.sarif` through `write_sarif` and reads the value back, rather than asserting on the passthrough list — my first version asserted against a function name that doesn't exist and silently **skipped**, which is exactly the failure mode worth avoiding in a test about evidence.

Documented in `KYA_MANIFEST.md` as schema **1.3**, with the per-analyzer table and the reasoning for not defaulting.

## Checks

```
tests/test_evidence_type.py   16 passed
full suite                    668 passed, 7 failed, 1 skipped
ruff check safeai/ tests/     clean
```

The 7 failures are pre-existing on `main` (`community_scan` + `scorecard`); baseline before this branch was 611 passed with the same 7.