### PR TITLE
feat: import portable KYA inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ safeai registry list --format html > registry.html   # shareable HTML inventory
 safeai registry show <agent-id>            # latest KYA record
 safeai registry history <agent-id>         # all scans for an agent
 safeai registry diff <agent-id> --from previous --to latest
+safeai registry export --output inventory.json
+safeai registry import inventory.json --dry-run
+safeai registry import inventory.json       # atomic, idempotent merge
 safeai registry export --format json --output inventory.json
 safeai registry export --format html --output inventory.html
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,7 +145,7 @@ These are the items that go deeper on your existing capabilities, but are not ye
 - 🔄 **Custom rule authoring** — the `--rules <dir>` directory loader (custom YAML overriding built-in rules by ID) shipped; authoring *scaffold* with fixtures, tests, and expected-findings tooling is planned.
 - ✅ **Control mappings** — OWASP Top 10 for Agentic Applications, OWASP Top 10 for LLM Applications, NIST AI RMF 1.0 (NIST AI 100-1) — presented as taxonomy, policy selection and prioritisation aid, explicitly **not** as coverage or compliance claims. **Shipped in v1.9.0**.
 - 🔄 Plugin and rule-pack versions recorded in every scan — the **ruleset version** is recorded on every scan (manifest + registry); per-parser/plugin versions are not yet recorded.
-- 🔄 **Portable registry export/import** — `registry export` (portable KYA inventory JSON, source- and secret-safe, `--include-history`/`--include-suppressed`) **shipped**; `import` is not yet implemented.
+- ✅ **Portable registry export/import** — `registry export` produces source- and secret-safe KYA inventory JSON, while `registry import <file>` performs an atomic, idempotent merge with `--dry-run` and metadata-only `--force` controls.
 - ⏳ **Opt-in usage telemetry** — anonymous, opt-in, local-first usage signal (SafeAI version, Python version, OS family, invocation context). Disabled by default; CI auto-disable; `DO_NOT_TRACK` respected; never transmits scan content. Two-phase: Phase 1 (documentation + PRIVACY.md) → Phase 2 (client implementation). **Phase 1 planned for v2.0.0.**
 
 ### Static authority correlation *(the community's Phase 3, offline)*

--- a/safeai/cmd/cli.py
+++ b/safeai/cmd/cli.py
@@ -10,7 +10,7 @@ Usage::
                             [--fail-on <level>] [--fail-on-new]
                             [--fail-on-escalation <level>]
     safeai init [--profile <name>] [--force]
-    safeai registry list|show|history|diff|export|components ...
+    safeai registry list|show|history|diff|export|import|components ...
 
 KYA (Know Your Agent) behavior:
   * Every scan produces normalized findings (stable fingerprints,
@@ -151,6 +151,14 @@ def _build_parser():
     reg_export.add_argument("--project", help="Export a single project ID")
     reg_export.add_argument("--include-history", action="store_true")
     reg_export.add_argument("--include-suppressed", action="store_true")
+
+    reg_import = reg_sub.add_parser("import", help="Import a portable KYA inventory document")
+    _common(reg_import)
+    reg_import.add_argument("file", help="Portable inventory JSON file")
+    reg_import.add_argument("--dry-run", action="store_true",
+                            help="Preview rows that would be imported without writing")
+    reg_import.add_argument("--force", action="store_true",
+                            help="Overwrite existing agent metadata with imported values")
 
     reg_meta = reg_sub.add_parser("metadata", help="View or set agent metadata (owner, environment)")
     _common(reg_meta)
@@ -455,7 +463,7 @@ def main(argv=None):
         if not getattr(args, "registry_command", None):
             parser.error(
                 "registry requires a subcommand: "
-                "list|show|history|components|diff|export|metadata",
+                "list|show|history|components|diff|export|import|metadata",
             )
         from safeai.cmd.registry_cli import run_registry_command
         exit_code = run_registry_command(args)

--- a/safeai/cmd/registry_cli.py
+++ b/safeai/cmd/registry_cli.py
@@ -7,6 +7,7 @@ evidence from a SQLite registry. Output formats: ``table`` (default),
 
 import json
 import os
+import sqlite3
 import sys
 
 from safeai.kya import STATIC_ANALYSIS_DISCLAIMER
@@ -333,6 +334,35 @@ def cmd_export(args):
     return 0
 
 
+def cmd_import(args):
+    """Import a portable inventory, or preview its deterministic merge plan."""
+    from safeai.kya.importer import import_inventory, load_inventory, plan_import
+    from safeai.kya.registry import init_registry, migrate
+
+    document = load_inventory(args.file)
+    if args.dry_run and not registry_exists(args.registry_path):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys=ON")
+        migrate(conn)
+    elif args.dry_run:
+        conn = connect(args.registry_path)
+    else:
+        conn, _ = init_registry(args.registry_path)
+    try:
+        if args.dry_run:
+            stats = plan_import(conn, document, force=args.force)
+        else:
+            stats = import_inventory(conn, document, force=args.force)
+    finally:
+        conn.close()
+    prefix = "Would import" if args.dry_run else "Imported"
+    print(f"{prefix} inventory from {args.file}")
+    for key, value in stats.items():
+        print(f"  {key}: {value}")
+    return 0
+
+
 def cmd_components(args):
     """List tracked components and optionally their consuming agents."""
     conn = _open_registry(args.registry_path)
@@ -493,6 +523,7 @@ def run_registry_command(args):
             "history": cmd_history,
             "diff": cmd_diff,
             "export": cmd_export,
+            "import": cmd_import,
             "components": cmd_components,
             "metadata": cmd_metadata,
         }[args.registry_command]

--- a/safeai/kya/exporter.py
+++ b/safeai/kya/exporter.py
@@ -11,14 +11,50 @@ from safeai.kya import STATIC_ANALYSIS_DISCLAIMER
 from safeai.kya.registry import (
     agent_history,
     get_agent,
+    get_agent_metadata,
     get_scan_findings,
+    get_tool_snapshots,
     latest_scan_id,
     list_agents,
+    list_components,
     list_projects,
 )
 from safeai.kya.util import utc_now_iso
 
-EXPORT_SCHEMA_VERSION = "1.0"
+EXPORT_SCHEMA_VERSION = "1.1"
+
+
+def _portable_components(conn, scan_id):
+    components = []
+    for row in list_components(conn, scan_id=scan_id):
+        data = row.get("data")
+        if isinstance(data, dict):
+            components.append(data)
+            continue
+        components.append({
+            "type": row.get("component_type"),
+            "subtype": row.get("component_subtype"),
+            "name": row.get("name"),
+            "path": row.get("file_path"),
+            "source": row.get("source"),
+            "line": row.get("line"),
+            "content_hash": row.get("content_hash"),
+        })
+    return components
+
+
+def _portable_lifecycle(conn, project_id, fingerprints):
+    if not fingerprints:
+        return []
+    rows = conn.execute(
+        "SELECT fl.*, fl.scan_id AS source_scan_id FROM finding_lifecycle fl "
+        "JOIN scans s ON s.scan_id = fl.scan_id WHERE s.project_id = ? ORDER BY fl.id",
+        (project_id,),
+    ).fetchall()
+    return [
+        {key: value for key, value in dict(row).items() if key not in {"id", "scan_id"}}
+        for row in rows if row["fingerprint"] in fingerprints
+    ]
 
 
 def export_inventory(conn, *, project_id=None, include_history=False, include_suppressed=False):
@@ -52,6 +88,7 @@ def export_inventory(conn, *, project_id=None, include_history=False, include_su
                     f for f in (record.get("findings") or [])
                     if include_suppressed or f.get("status") != "suppressed"
                 ],
+                "metadata": get_agent_metadata(conn, record["agent_id"]),
             }
             if include_history:
                 entry["history"] = agent_history(conn, record["agent_id"])
@@ -61,6 +98,10 @@ def export_inventory(conn, *, project_id=None, include_history=False, include_su
         latest_findings = get_scan_findings(conn, latest) if latest else []
         if not include_suppressed:
             latest_findings = [f for f in latest_findings if f.get("status") != "suppressed"]
+        exported_fingerprints = {
+            finding.get("fingerprint") for finding in latest_findings
+            if finding.get("fingerprint")
+        }
 
         export_projects.append({
             "project_id": pid,
@@ -69,6 +110,9 @@ def export_inventory(conn, *, project_id=None, include_history=False, include_su
             "agents": agents,
             "latest_scan_id": latest,
             "latest_findings": latest_findings,
+            "component_snapshots": _portable_components(conn, latest) if latest else [],
+            "tool_snapshots": get_tool_snapshots(conn, latest) if latest else [],
+            "finding_lifecycle": _portable_lifecycle(conn, pid, exported_fingerprints),
         })
 
     return {

--- a/safeai/kya/importer.py
+++ b/safeai/kya/importer.py
@@ -1,0 +1,481 @@
+"""Portable KYA inventory import.
+
+The importer validates the complete document before writing, then merges the
+source inventory in one transaction.  Re-importing the same document is
+idempotent because every imported snapshot is attached to a deterministic
+import scan ID and table-native identities are preserved.
+"""
+
+import json
+
+from safeai.kya.exporter import EXPORT_SCHEMA_VERSION
+from safeai.kya.registry import RegistryError
+from safeai.kya.util import sha256_text, utc_now_iso
+
+SUPPORTED_SCHEMA_VERSIONS = {"1.0", EXPORT_SCHEMA_VERSION}
+
+
+def load_inventory(path):
+    """Load and validate a portable inventory JSON document."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            document = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RegistryError(f"Unable to read inventory {path}: {exc}") from exc
+    validate_inventory(document)
+    return document
+
+
+def validate_inventory(document):
+    """Reject malformed or unsupported inventories before any registry write."""
+    if not isinstance(document, dict):
+        raise RegistryError("Invalid inventory: root must be a JSON object")
+    if document.get("export_type") != "safeai.kya.inventory":
+        raise RegistryError("Invalid inventory: export_type must be 'safeai.kya.inventory'")
+    version = str(document.get("schema_version") or "")
+    if version not in SUPPORTED_SCHEMA_VERSIONS:
+        supported = ", ".join(sorted(SUPPORTED_SCHEMA_VERSIONS))
+        raise RegistryError(
+            f"Unsupported inventory schema_version '{version}' (supported: {supported})"
+        )
+    projects = document.get("projects")
+    if not isinstance(projects, list):
+        raise RegistryError("Invalid inventory: projects must be a list")
+
+    project_ids = set()
+    agent_projects = {}
+    for project in projects:
+        if not isinstance(project, dict):
+            raise RegistryError("Invalid inventory: each project must be an object")
+        project_id = project.get("project_id")
+        if not isinstance(project_id, str) or not project_id.strip():
+            raise RegistryError("Invalid inventory: every project needs a project_id")
+        if project_id in project_ids:
+            raise RegistryError(f"Invalid inventory: duplicate project_id '{project_id}'")
+        project_ids.add(project_id)
+        agents = project.get("agents", [])
+        if not isinstance(agents, list):
+            raise RegistryError(f"Invalid inventory: agents for '{project_id}' must be a list")
+        for agent in agents:
+            if not isinstance(agent, dict):
+                raise RegistryError("Invalid inventory: each agent must be an object")
+            agent_id = agent.get("agent_id")
+            if not isinstance(agent_id, str) or not agent_id.strip():
+                raise RegistryError("Invalid inventory: every agent needs an agent_id")
+            previous_project = agent_projects.setdefault(agent_id, project_id)
+            if previous_project != project_id:
+                raise RegistryError(
+                    f"Invalid inventory: agent_id '{agent_id}' belongs to multiple projects"
+                )
+        for key in (
+            "latest_findings",
+            "component_snapshots",
+            "finding_lifecycle",
+            "tool_snapshots",
+        ):
+            value = project.get(key, [])
+            if not isinstance(value, list):
+                raise RegistryError(f"Invalid inventory: {key} for '{project_id}' must be a list")
+
+
+def _import_scan_id(document, project):
+    payload = {
+        "schema_version": document["schema_version"],
+        "generated_at": document.get("generated_at"),
+        "project": project,
+    }
+    digest = sha256_text(json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str))
+    return f"import-{digest[:32]}"
+
+
+def _exists(conn, sql, params):
+    return conn.execute(sql, params).fetchone() is not None
+
+
+def plan_import(conn, document, *, force=False):
+    """Return the rows an import would add or update without mutating the registry."""
+    validate_inventory(document)
+    counts = {
+        "projects": 0,
+        "scans": 0,
+        "agents": 0,
+        "agent_snapshots": 0,
+        "metadata": 0,
+        "findings": 0,
+        "component_snapshots": 0,
+        "finding_lifecycle": 0,
+        "tool_snapshots": 0,
+    }
+    for project in document["projects"]:
+        project_id = project["project_id"]
+        scan_id = _import_scan_id(document, project)
+        if not _exists(conn, "SELECT 1 FROM projects WHERE project_id = ?", (project_id,)):
+            counts["projects"] += 1
+        new_scan = not _exists(conn, "SELECT 1 FROM scans WHERE scan_id = ?", (scan_id,))
+        if new_scan:
+            counts["scans"] += 1
+        for agent in project.get("agents", []):
+            agent_id = agent["agent_id"]
+            existing_agent = conn.execute(
+                "SELECT project_id FROM agents WHERE agent_id = ?", (agent_id,)
+            ).fetchone()
+            if existing_agent and existing_agent["project_id"] != project_id:
+                raise RegistryError(
+                    f"Cannot import agent_id '{agent_id}': it belongs to project "
+                    f"'{existing_agent['project_id']}', not '{project_id}'"
+                )
+            if not existing_agent:
+                counts["agents"] += 1
+            if not _exists(
+                conn,
+                "SELECT 1 FROM agent_snapshots WHERE agent_id = ? AND scan_id = ?",
+                (agent_id, scan_id),
+            ):
+                counts["agent_snapshots"] += 1
+            metadata = agent.get("metadata")
+            if metadata:
+                existing_metadata = conn.execute(
+                    "SELECT owner, environment, purpose, lifecycle_status FROM agent_metadata "
+                    "WHERE agent_id = ?",
+                    (agent_id,),
+                ).fetchone()
+                if force or not existing_metadata or any(
+                    existing_metadata[key] is None and metadata.get(key) is not None
+                    for key in ("owner", "environment", "purpose", "lifecycle_status")
+                ):
+                    counts["metadata"] += 1
+        for finding in project.get("latest_findings", []):
+            fingerprint = finding.get("fingerprint") if isinstance(finding, dict) else None
+            if fingerprint and not _exists(
+                conn, "SELECT 1 FROM findings WHERE fingerprint = ?", (fingerprint,)
+            ):
+                counts["findings"] += 1
+        if new_scan:
+            counts["component_snapshots"] += len(_unique_components(project))
+            importable_fingerprints = {
+                finding.get("fingerprint")
+                for finding in project.get("latest_findings", [])
+                if isinstance(finding, dict) and finding.get("fingerprint")
+            }
+            importable_fingerprints.update(
+                row["fingerprint"]
+                for row in conn.execute("SELECT fingerprint FROM findings").fetchall()
+            )
+            counts["finding_lifecycle"] += sum(
+                event["fingerprint"] in importable_fingerprints
+                for event in _unique_lifecycle(project)
+            )
+            counts["tool_snapshots"] += len(_unique_tools(project))
+    return counts
+
+
+def _unique_components(project):
+    unique = {}
+    for component in project.get("component_snapshots", []):
+        if not isinstance(component, dict):
+            continue
+        identity = (component.get("type"), component.get("path") or component.get("file"))
+        if all(identity):
+            unique.setdefault(identity, component)
+    return list(unique.values())
+
+
+def _unique_lifecycle(project):
+    unique = {}
+    for event in project.get("finding_lifecycle", []):
+        if not isinstance(event, dict) or not event.get("fingerprint"):
+            continue
+        identity = (
+            event.get("fingerprint"),
+            event.get("event"),
+            event.get("created_at"),
+            event.get("source_scan_id") or event.get("scan_id"),
+        )
+        unique.setdefault(identity, event)
+    return list(unique.values())
+
+
+def _unique_tools(project):
+    unique = {}
+    for tool in project.get("tool_snapshots", []):
+        if not isinstance(tool, dict) or not tool.get("tool_key"):
+            continue
+        identity = (tool.get("agent_id"), tool["tool_key"])
+        unique.setdefault(identity, tool)
+    return list(unique.values())
+
+
+def import_inventory(conn, document, *, force=False):
+    """Merge a validated inventory into ``conn`` as one atomic transaction."""
+    validate_inventory(document)
+    planned = plan_import(conn, document, force=force)
+    now = utc_now_iso()
+    try:
+        with conn:
+            for project in document["projects"]:
+                _import_project(conn, document, project, now=now, force=force)
+    except Exception as exc:
+        if isinstance(exc, RegistryError):
+            raise
+        raise RegistryError(f"Failed to import inventory: {exc}") from exc
+    return planned
+
+
+def _import_project(conn, document, project, *, now, force):
+    project_id = project["project_id"]
+    scan_id = _import_scan_id(document, project)
+    conn.execute(
+        "INSERT OR IGNORE INTO projects(project_id, name, source_root, remote_fingerprint, "
+        "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            project_id,
+            project.get("name"),
+            project.get("source_root"),
+            None,
+            now,
+            now,
+        ),
+    )
+
+    findings = [
+        finding for finding in project.get("latest_findings", [])
+        if isinstance(finding, dict) and finding.get("fingerprint")
+    ]
+    agents = project.get("agents", [])
+    manifest = {
+        "import": {
+            "export_schema_version": document["schema_version"],
+            "generated_at": document.get("generated_at"),
+        },
+        "project": {"project_id": project_id, "name": project.get("name")},
+        "agents": agents,
+        "findings": findings,
+        "components": _unique_components(project),
+        "tool_surface": _unique_tools(project),
+    }
+    manifest_json = json.dumps(manifest, sort_keys=True, default=str)
+    manifest_hash = sha256_text(manifest_json)
+    completed_at = document.get("generated_at") or now
+    conn.execute(
+        "INSERT OR IGNORE INTO scans(scan_id, project_id, started_at, completed_at, "
+        "files_scanned, safeai_version, ruleset_version, config_hash, commit_sha, branch, tag, "
+        "manifest_json, manifest_hash, policy_outcome, risk_score, agent_count, finding_count, "
+        "severity_counts_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            scan_id,
+            project_id,
+            completed_at,
+            completed_at,
+            None,
+            "portable-import",
+            None,
+            None,
+            None,
+            None,
+            None,
+            manifest_json,
+            manifest_hash,
+            "imported",
+            None,
+            len(agents),
+            len(findings),
+            "{}",
+        ),
+    )
+
+    for agent in agents:
+        _import_agent(conn, project_id, scan_id, agent, now=now, force=force)
+    for finding in findings:
+        _import_finding(conn, scan_id, finding)
+    for component in _unique_components(project):
+        _import_component(conn, scan_id, component)
+    for tool in _unique_tools(project):
+        _import_tool(conn, scan_id, tool)
+    for event in _unique_lifecycle(project):
+        _import_lifecycle(conn, scan_id, event, fallback_created_at=completed_at)
+
+
+def _import_agent(conn, project_id, scan_id, agent, *, now, force):
+    agent_id = agent["agent_id"]
+    source_locations = agent.get("source_locations") or []
+    primary_path = source_locations[0].get("path") if source_locations else None
+    conn.execute(
+        "INSERT OR IGNORE INTO agents(agent_id, project_id, name, agent_type, framework, "
+        "primary_path, first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            agent_id,
+            project_id,
+            agent.get("name"),
+            agent.get("agent_type"),
+            agent.get("framework"),
+            primary_path,
+            agent.get("first_seen") or now,
+            agent.get("last_seen") or now,
+        ),
+    )
+    snapshot = {
+        "agent_id": agent_id,
+        "name": agent.get("name"),
+        "agent_type": agent.get("agent_type"),
+        "framework": agent.get("framework"),
+        "source_locations": source_locations,
+        "capabilities": agent.get("capabilities") or [],
+        "tools": agent.get("tools") or [],
+        "confidence": agent.get("confidence"),
+        "first_seen": agent.get("first_seen"),
+        "last_seen": agent.get("last_seen"),
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO agent_snapshots(agent_id, scan_id, snapshot_json, "
+        "capability_count, finding_count, confidence) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            agent_id,
+            scan_id,
+            json.dumps(snapshot, sort_keys=True, default=str),
+            len(snapshot["capabilities"]),
+            len(agent.get("findings") or []),
+            agent.get("confidence"),
+        ),
+    )
+    metadata = agent.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    existing = conn.execute(
+        "SELECT owner, environment, purpose, lifecycle_status FROM agent_metadata "
+        "WHERE agent_id = ?",
+        (agent_id,),
+    ).fetchone()
+    if existing and not force:
+        values = {
+            key: existing[key] if existing[key] is not None else metadata.get(key)
+            for key in ("owner", "environment", "purpose", "lifecycle_status")
+        }
+    else:
+        values = {
+            key: metadata.get(key)
+            for key in ("owner", "environment", "purpose", "lifecycle_status")
+        }
+    conn.execute(
+        "INSERT INTO agent_metadata(agent_id, owner, environment, purpose, lifecycle_status, "
+        "updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(agent_id) DO UPDATE SET "
+        "owner=excluded.owner, environment=excluded.environment, purpose=excluded.purpose, "
+        "lifecycle_status=excluded.lifecycle_status, updated_at=excluded.updated_at",
+        (
+            agent_id,
+            values["owner"],
+            values["environment"],
+            values["purpose"],
+            values["lifecycle_status"] or "active",
+            now,
+        ),
+    )
+
+
+def _import_finding(conn, scan_id, finding):
+    fingerprint = finding["fingerprint"]
+    location = finding.get("location") or {}
+    path = location.get("path") or finding.get("path")
+    line = location.get("line_start") or finding.get("line")
+    conn.execute(
+        "INSERT OR IGNORE INTO findings(fingerprint, rule_id, severity, title, message, "
+        "remediation, confidence, first_seen_scan, last_seen_scan, status) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            fingerprint,
+            finding.get("rule_id"),
+            finding.get("severity"),
+            finding.get("title"),
+            finding.get("message"),
+            finding.get("remediation"),
+            finding.get("confidence"),
+            scan_id,
+            scan_id,
+            finding.get("status", "new"),
+        ),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO scan_findings(scan_id, fingerprint, status, severity, rule_id, "
+        "path, line, finding_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            scan_id,
+            fingerprint,
+            finding.get("status", "new"),
+            finding.get("severity"),
+            finding.get("rule_id"),
+            path,
+            line,
+            json.dumps(finding, sort_keys=True, default=str),
+        ),
+    )
+
+
+def _import_component(conn, scan_id, component):
+    component_type = component.get("type")
+    file_path = component.get("path") or component.get("file")
+    conn.execute(
+        "INSERT OR IGNORE INTO component_snapshots(scan_id, component_type, component_subtype, "
+        "name, file_path, source, line, data_json, first_seen_scan, last_seen_scan, content_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            scan_id,
+            component_type,
+            component.get("subtype"),
+            component.get("name"),
+            file_path,
+            component.get("source"),
+            component.get("line"),
+            json.dumps(component, sort_keys=True, default=str),
+            scan_id,
+            scan_id,
+            component.get("content_hash"),
+        ),
+    )
+
+
+def _import_tool(conn, scan_id, tool):
+    details = tool.get("tool") or {}
+    conn.execute(
+        "INSERT OR IGNORE INTO agent_tool_snapshots(agent_id, scan_id, tool_key, tool_kind, "
+        "tool_name, framework, capabilities_json, access_summary) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            tool.get("agent_id"),
+            scan_id,
+            tool["tool_key"],
+            details.get("kind"),
+            details.get("name"),
+            details.get("framework"),
+            json.dumps(tool.get("capabilities") or [], sort_keys=True, default=str),
+            tool.get("access_summary"),
+        ),
+    )
+
+
+def _import_lifecycle(conn, scan_id, event, *, fallback_created_at):
+    fingerprint = event["fingerprint"]
+    if not _exists(conn, "SELECT 1 FROM findings WHERE fingerprint = ?", (fingerprint,)):
+        return
+    lifecycle_event = event.get("event") or "introduced"
+    created_at = event.get("created_at") or fallback_created_at
+    if _exists(
+        conn,
+        "SELECT 1 FROM finding_lifecycle WHERE fingerprint = ? AND scan_id = ? "
+        "AND event = ? AND created_at = ?",
+        (fingerprint, scan_id, lifecycle_event, created_at),
+    ):
+        return
+    conn.execute(
+        "INSERT INTO finding_lifecycle(fingerprint, scan_id, event, previous_event, rule_id, "
+        "severity, file_path, line, message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            fingerprint,
+            scan_id,
+            lifecycle_event,
+            event.get("previous_event"),
+            event.get("rule_id"),
+            event.get("severity"),
+            event.get("file_path"),
+            event.get("line"),
+            event.get("message"),
+            created_at,
+        ),
+    )

--- a/safeai/kya/registry/persist.py
+++ b/safeai/kya/registry/persist.py
@@ -98,7 +98,7 @@ def _persist_tool_surface(conn, manifest, scan_id, stats):
 def get_tool_snapshots(conn, scan_id):
     """Return the stored per-tool surface for a scan, sorted by tool key."""
     rows = conn.execute(
-        "SELECT tool_key, tool_kind, tool_name, framework, capabilities_json, access_summary "
+        "SELECT agent_id, tool_key, tool_kind, tool_name, framework, capabilities_json, access_summary "
         "FROM agent_tool_snapshots WHERE scan_id = ? ORDER BY tool_key",
         (scan_id,),
     ).fetchall()
@@ -109,6 +109,7 @@ def get_tool_snapshots(conn, scan_id):
         except (TypeError, ValueError):
             capabilities = []
         surface.append({
+            "agent_id": row["agent_id"],
             "tool_key": row["tool_key"],
             "tool": {
                 "kind": row["tool_kind"],

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -115,16 +115,179 @@ def test_registry_export(kya_project, tmp_path):
     with open(out_path) as fh:
         document = json.load(fh)
     assert document["export_type"] == "safeai.kya.inventory"
-    assert document["schema_version"] == "1.0"
+    assert document["schema_version"] == "1.1"
     project = document["projects"][0]
     assert project["agents"]
     assert project["agents"][0]["history"]
     assert project["latest_findings"]
     assert "limitations" in document
+    assert "component_snapshots" in project
+    assert "tool_snapshots" in project
+    assert "finding_lifecycle" in project
 
     with open(out_path, encoding="utf-8") as fh:
         raw = fh.read()
     assert "sk-1234567890abcdefghij" not in raw
+
+
+def test_registry_import_is_complete_and_idempotent(kya_project, tmp_path, capsys):
+    _two_scans(kya_project, tmp_path)
+    source = kya_project["registry"]
+    agent_id = _agent_id(source)
+
+    from safeai.kya.registry import connect, latest_scan_id, set_agent_metadata
+
+    conn = connect(source)
+    try:
+        set_agent_metadata(
+            conn,
+            agent_id,
+            owner="source-team",
+            environment="production",
+            purpose="risk review",
+        )
+        scan_id = latest_scan_id(conn)
+        conn.execute(
+            "INSERT INTO component_snapshots(scan_id, component_type, name, file_path, "
+            "data_json, first_seen_scan, last_seen_scan, content_hash) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                scan_id,
+                "prompt",
+                "system-prompt",
+                "prompts/system.txt",
+                json.dumps({"type": "prompt", "name": "system-prompt", "path": "prompts/system.txt"}),
+                scan_id,
+                scan_id,
+                "component-hash",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    inventory = os.path.join(str(tmp_path), "portable.json")
+    assert main([
+        "registry", "export", "--registry", source, "--output", inventory,
+        "--include-history",
+    ]) == 0
+    capsys.readouterr()
+
+    target = os.path.join(str(tmp_path), "imported", "registry.db")
+    assert main(["registry", "import", inventory, "--registry", target]) == 0
+    first_output = capsys.readouterr().out
+    assert "Imported inventory" in first_output
+
+    conn = connect(target)
+    try:
+        first_counts = {
+            table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in (
+                "projects", "scans", "agents", "agent_snapshots", "findings",
+                "scan_findings", "component_snapshots", "finding_lifecycle",
+                "agent_tool_snapshots", "agent_metadata",
+            )
+        }
+        metadata = conn.execute(
+            "SELECT owner, environment, purpose FROM agent_metadata WHERE agent_id = ?",
+            (agent_id,),
+        ).fetchone()
+        assert tuple(metadata) == ("source-team", "production", "risk review")
+        assert first_counts["scans"] == 1
+        assert first_counts["agents"] >= 1
+        assert first_counts["findings"] >= 1
+        assert first_counts["component_snapshots"] >= 1
+        assert first_counts["finding_lifecycle"] >= 1
+        assert first_counts["agent_tool_snapshots"] >= 1
+    finally:
+        conn.close()
+
+    assert main(["registry", "import", inventory, "--registry", target]) == 0
+    capsys.readouterr()
+    conn = connect(target)
+    try:
+        second_counts = {
+            table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            for table in first_counts
+        }
+    finally:
+        conn.close()
+    assert second_counts == first_counts
+
+
+def test_registry_import_metadata_merge_dry_run_and_force(kya_project, tmp_path, capsys):
+    main([
+        "scan", kya_project["root"], "--registry", kya_project["registry"],
+        "--sarif", os.path.join(tmp_path, "r.sarif"),
+    ])
+    source = kya_project["registry"]
+    agent_id = _agent_id(source)
+    from safeai.kya.registry import connect, set_agent_metadata
+
+    conn = connect(source)
+    try:
+        set_agent_metadata(conn, agent_id, owner="source", environment="production")
+        conn.commit()
+    finally:
+        conn.close()
+    inventory = os.path.join(str(tmp_path), "portable.json")
+    main(["registry", "export", "--registry", source, "--output", inventory])
+    capsys.readouterr()
+
+    absent = os.path.join(str(tmp_path), "dry-run", "registry.db")
+    assert main(["registry", "import", inventory, "--registry", absent, "--dry-run"]) == 0
+    assert "Would import inventory" in capsys.readouterr().out
+    assert not os.path.exists(absent)
+
+    target = os.path.join(str(tmp_path), "target", "registry.db")
+    main(["registry", "import", inventory, "--registry", target])
+    capsys.readouterr()
+    conn = connect(target)
+    try:
+        conn.execute(
+            "UPDATE agent_metadata SET owner = ?, environment = ? WHERE agent_id = ?",
+            ("local", "staging", agent_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    main(["registry", "import", inventory, "--registry", target])
+    capsys.readouterr()
+    conn = connect(target)
+    try:
+        row = conn.execute(
+            "SELECT owner, environment FROM agent_metadata WHERE agent_id = ?", (agent_id,)
+        ).fetchone()
+        assert tuple(row) == ("local", "staging")
+    finally:
+        conn.close()
+
+    main(["registry", "import", inventory, "--registry", target, "--force"])
+    capsys.readouterr()
+    conn = connect(target)
+    try:
+        row = conn.execute(
+            "SELECT owner, environment FROM agent_metadata WHERE agent_id = ?", (agent_id,)
+        ).fetchone()
+        assert tuple(row) == ("source", "production")
+    finally:
+        conn.close()
+
+
+def test_registry_import_rejects_corrupt_and_invalid_json(tmp_path, capsys):
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    target = tmp_path / "registry.db"
+    assert main(["registry", "import", str(corrupt), "--registry", str(target)]) == 2
+    assert "Unable to read inventory" in capsys.readouterr().err
+    assert not target.exists()
+
+    invalid = tmp_path / "invalid.json"
+    invalid.write_text(json.dumps({"schema_version": "1.1", "projects": []}), encoding="utf-8")
+    assert main(["registry", "import", str(invalid), "--registry", str(target)]) == 2
+    assert "export_type" in capsys.readouterr().err
+    assert not target.exists()
 
 
 def test_registry_export_excludes_suppressed_by_default(kya_project, tmp_path):


### PR DESCRIPTION
## Summary

- add `safeai registry import <file>` for portable KYA inventory JSON
- merge agents, metadata, findings, components, lifecycle events, and tool snapshots atomically and idempotently
- support non-writing `--dry-run` previews and metadata replacement with `--force`

## Validation

- `python -m pytest -q` (747 passed, 1 skipped)
- `ruff check` on changed Python files

Closes #117
