### PR TITLE
ci: run canonical release checklist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,9 @@ jobs:
           pip install --require-hashes -r requirements.txt
           pip install --no-deps -e .
 
+      - name: "Check: canonical release checklist"
+        run: python scripts/check_release.py
+
       - name: "Check: version string matches tag"
         run: |
           TAG_VERSION="${{ steps.meta.outputs.version }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,13 @@ python -m pytest -v
 
 # Run with coverage
 python -m pytest --cov=safeai
+
+# Verify release metadata, rules, changelog, and Action I/O consistency
+python scripts/check_release.py
 ```
+
+The release workflow runs the same checker before building or publishing
+artifacts, so failures block the release at the pre-release checklist gate.
 
 ---
 


### PR DESCRIPTION
Closes #122

The pre-release checklist now runs `scripts/check_release.py` immediately after installing dependencies, so its version, rule-schema, changelog, and Action-contract checks can block a release. Contributor docs expose the same local command.

Validation: canonical checker and its failure path verified; workflow YAML parsed; 744 tests passed with 1 skip; `git diff --check` passed. Repository-wide Ruff has 11 unrelated existing diagnostics.
